### PR TITLE
Fix time display for GUI

### DIFF
--- a/src/UIState/SeeDeviceUptime.cpp
+++ b/src/UIState/SeeDeviceUptime.cpp
@@ -9,13 +9,14 @@
 #include "TC_util.h"
 
 void SeeDeviceUptime::loop() {
-  COUT("loop()");
   unsigned long ms = millis();
-  int days = floor(ms / 86400000);
-  int hours = floor((ms - (days * 86400000)) / 3600000);
-  int minutes = floor((ms - (days * 86400000) - (hours * 3600000)) / 60000);
-  int seconds = floor((ms - (days * 86400000) - (hours * 3600000) - (minutes * 60000)) / 1000);
+  COUT("SeeDeviceUptime::loop() at " << ms);
+  int days = ms / 86400000;
+  int hours = (ms - (days * 86400000)) / 3600000;
+  int minutes = (ms - (days * 86400000) - (hours * 3600000)) / 60000;
+  int seconds = (ms - (days * 86400000) - (hours * 3600000) - (minutes * 60000)) / 1000;
   char buffer[17];
+  COUT("days: " << days << "; hours: " << hours << "; mins: " << minutes << "; secs: " << seconds);
   sprintf(buffer, "Up d:%02i %02i:%02i:%02i", days, hours, minutes, seconds);
   LiquidCrystal_TC::instance()->writeLine(DateTime_TC::now().as16CharacterString(), 0);
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);


### PR DESCRIPTION
Fix #84. Calculation of offset between host and Arduino mock was wrong and has been fixed. Also, we don't need the `floor()` function (which returns a float) when we are doing integer division.