### PR TITLE
Refactor pH Control

### DIFF
--- a/src/Devices/PHControl.cpp
+++ b/src/Devices/PHControl.cpp
@@ -1,10 +1,40 @@
 #include "PHControl.h"
 
+#include "Devices/EEPROM_TC.h"
 #include "PID_TC.h"
+#include "TC_util.h"
+
+const double DEFAULT_PH = 7.125;
+
+//  class instance variables
+/**
+ * static variable for singleton
+ */
+PHControl *PHControl::_instance = nullptr;
+
+//  class methods
+/**
+ * static member function to return singleton
+ */
+PHControl *PHControl::instance() {
+  if (!_instance) {
+    _instance = new PHControl();
+  }
+  return _instance;
+}
 
 PHControl::PHControl() {
   window_start_time = millis();
   digitalWrite(PIN, HIGH);
+  targetPh = EEPROM_TC::instance()->getPH();
+  if (isnan(targetPh)) {
+    targetPh = DEFAULT_PH;
+  }
+}
+
+void PHControl::setTargetPh(double newPh) {
+  targetPh = newPh;
+  EEPROM_TC::instance()->setPH(newPh);
 }
 
 void PHControl::updateControl(double pH) {
@@ -16,10 +46,15 @@ void PHControl::updateControl(double pH) {
   long now = millis();
   if (now - window_start_time > WINDOW_SIZE) {  // time to shift the Relay Window
     window_start_time += WINDOW_SIZE;
+    COUT("now: " << now << "; window_start_time: " << window_start_time);
   }
-  if ((onTime > SOLENOID_OPENING_TIME) && (onTime > (now - window_start_time))) {
+  COUT("target: " << targetPh << "; current: " << pH << "; onTime = " << onTime
+                  << "; left = " << now - window_start_time);
+  if ((onTime > SOLENOID_OPENING_TIME) && (onTime >= (now - window_start_time))) {
+    COUT("set pin low");
     digitalWrite(PIN, LOW);  // OPEN CO2 solenoid
   } else {
+    COUT("set pin high");
     digitalWrite(PIN, HIGH);  // CLOSE CO2 solenoid
   }
 }

--- a/src/Devices/PHControl.h
+++ b/src/Devices/PHControl.h
@@ -2,6 +2,9 @@
 
 class PHControl {
 private:
+  // Class variable
+  static PHControl* _instance;
+  // instance variables
   const int PIN = 49;
   const int SOLENOID_OPENING_TIME = 100;
   double targetPh;
@@ -9,12 +12,14 @@ private:
   long onTime = 0;
   long window_start_time;
   bool usePID = true;
+  PHControl();
 
 public:
-  PHControl();
-  void setTargetPh(double newPh) {
-    targetPh = newPh;
+  static PHControl* instance();
+  double getTargetPh() {
+    return targetPh;
   }
+  void setTargetPh(double newPh);
   void setUsePID(bool flag) {
     usePID = flag;
   }

--- a/src/TankControllerLib.cpp
+++ b/src/TankControllerLib.cpp
@@ -2,6 +2,7 @@
 
 #include "Devices/Keypad_TC.h"
 #include "Devices/LiquidCrystal_TC.h"
+#include "Devices/PHControl.h"
 #include "Devices/PHProbe.h"
 #include "Devices/SD_TC.h"
 #include "Devices/Serial_TC.h"
@@ -95,6 +96,7 @@ void TankControllerLib::loop() {
   handleUI();
   // update TemperatureControl
   // update PHControl
+  PHControl::instance()->updateControl(PHProbe::instance()->getPh());
   // write data to SD
   // write data to Google Sheets
 }

--- a/src/UIState/MainMenu.cpp
+++ b/src/UIState/MainMenu.cpp
@@ -2,6 +2,7 @@
 
 #include "CalibrationManagement.h"
 #include "Devices/LiquidCrystal_TC.h"
+#include "Devices/PHControl.h"
 #include "Devices/PHProbe.h"
 #include "Devices/TempProbe_TC.h"
 #include "EnablePID.h"
@@ -220,9 +221,9 @@ void MainMenu::selectSet() {
 
 // show current temp and pH
 void MainMenu::idle() {
-  PHProbe *pPHProbe = PHProbe::instance();
   char output[17];
-  snprintf(output, sizeof(output), "pH=%01.3f   %1.3f", pPHProbe->getPh(), 7.125);
+  snprintf(output, sizeof(output), "pH=%01.3f   %1.3f", PHProbe::instance()->getPh(),
+           PHControl::instance()->getTargetPh());
   LiquidCrystal_TC::instance()->writeLine(output, 0);
   TempProbe_TC *tempProbe = TempProbe_TC::instance();
   double temp = tempProbe->getRunningAverage();

--- a/src/UIState/SetPHSetPoint.cpp
+++ b/src/UIState/SetPHSetPoint.cpp
@@ -4,11 +4,11 @@
 
 #include "SetPHSetPoint.h"
 
-#include "Devices/EEPROM_TC.h"
 #include "Devices/LiquidCrystal_TC.h"
+#include "Devices/PHControl.h"
 
 void SetPHSetPoint::setValue(double value) {
-  EEPROM_TC::instance()->setPH(value);
+  PHControl::instance()->setTargetPh(value);
 
   char output[17];
   snprintf(output, sizeof(output), "New pH=%.4f", value);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -4,82 +4,92 @@
 
 #include "PHControl.h"
 
+/**
+ * cycle the control through to a point of being off
+ */
+void reset() {
+  PHControl* singleton = PHControl::instance();
+  singleton->setUsePID(false);
+  singleton->setTargetPh(7.00);
+  singleton->updateControl(7.00);
+  delay(10000);
+  singleton->updateControl(7.00);
+}
+
+unittest_setup() {
+  reset();
+}
+
+unittest_teardown() {
+  reset();
+}
+
 // updateControl function
 unittest(beforeTenSeconds) {
   const int PIN = 49;
   GodmodeState* state = GODMODE();
-  state->reset();
-  PHControl controlSolenoid;
+  PHControl* controlSolenoid = PHControl::instance();
   assertEqual(HIGH, state->digitalPin[PIN]);
-  controlSolenoid.setTargetPh(7.00);
-  controlSolenoid.setUsePID(false);
-  controlSolenoid.updateControl(8.00);
+  controlSolenoid->setTargetPh(7.00);
+  controlSolenoid->updateControl(8.00);
   assertEqual(LOW, state->digitalPin[PIN]);
   delay(9500);
-  controlSolenoid.updateControl(8.00);
+  controlSolenoid->updateControl(8.00);
   assertEqual(LOW, state->digitalPin[PIN]);
 }
 
 unittest(afterTenSecondsButPhStillHigher) {
   const int PIN = 49;
   GodmodeState* state = GODMODE();
-  state->reset();
-  PHControl controlSolenoid;
+  PHControl* controlSolenoid = PHControl::instance();
   assertEqual(HIGH, state->digitalPin[PIN]);
-  controlSolenoid.setTargetPh(7.00);
-  controlSolenoid.setUsePID(false);
-  controlSolenoid.updateControl(8.00);
+  controlSolenoid->setTargetPh(7.00);
+  controlSolenoid->updateControl(8.00);
   assertEqual(LOW, state->digitalPin[PIN]);
   delay(9500);
-  controlSolenoid.updateControl(8.00);
+  controlSolenoid->updateControl(8.00);
   assertEqual(LOW, state->digitalPin[PIN]);
   delay(1000);
-  controlSolenoid.updateControl(7.25);
+  controlSolenoid->updateControl(7.25);
   assertEqual(LOW, state->digitalPin[PIN]);
 }
 
 unittest(afterTenSecondsAndPhIsLower) {
   const int PIN = 49;
   GodmodeState* state = GODMODE();
-  state->reset();
-  PHControl controlSolenoid;
+  PHControl* controlSolenoid = PHControl::instance();
   assertEqual(HIGH, state->digitalPin[PIN]);
-  controlSolenoid.setTargetPh(7.00);
-  controlSolenoid.setUsePID(false);
-  controlSolenoid.updateControl(8.00);
+  controlSolenoid->setTargetPh(7.00);
+  controlSolenoid->updateControl(8.00);
   assertEqual(LOW, state->digitalPin[PIN]);
   delay(9500);
-  controlSolenoid.updateControl(8.00);
+  controlSolenoid->updateControl(8.00);
   assertEqual(LOW, state->digitalPin[PIN]);
   delay(1000);
-  controlSolenoid.updateControl(6.75);
+  controlSolenoid->updateControl(6.75);
   assertEqual(HIGH, state->digitalPin[PIN]);
 }
 
 unittest(beforeTenSecondsButPhIsLower) {
   const int PIN = 49;
   GodmodeState* state = GODMODE();
-  state->reset();
-  PHControl controlSolenoid;
+  PHControl* controlSolenoid = PHControl::instance();
   assertEqual(HIGH, state->digitalPin[PIN]);
-  controlSolenoid.setTargetPh(7.00);
-  controlSolenoid.setUsePID(false);
-  controlSolenoid.updateControl(8.00);
+  controlSolenoid->setTargetPh(7.00);
+  controlSolenoid->updateControl(8.00);
   assertEqual(LOW, state->digitalPin[PIN]);
   delay(7500);
-  controlSolenoid.updateControl(6.75);
+  controlSolenoid->updateControl(6.75);
   assertEqual(HIGH, state->digitalPin[PIN]);
 }
 
 unittest(PhEvenWithTarget) {
   const int PIN = 49;
   GodmodeState* state = GODMODE();
-  state->reset();
-  PHControl controlSolenoid;
+  PHControl* controlSolenoid = PHControl::instance();
   assertEqual(HIGH, state->digitalPin[PIN]);
-  controlSolenoid.setTargetPh(7.00);
-  controlSolenoid.setUsePID(false);
-  controlSolenoid.updateControl(7.00);
+  controlSolenoid->setTargetPh(7.00);
+  controlSolenoid->updateControl(7.00);
   assertEqual(HIGH, state->digitalPin[PIN]);
 }
 

--- a/test/SetPHSetPoint.cpp
+++ b/test/SetPHSetPoint.cpp
@@ -4,16 +4,20 @@
 #include <ArduinoUnitTests.h>
 
 #include "Devices/LiquidCrystal_TC.h"
+#include "Devices/PHControl.h"
 #include "EEPROM_TC.h"
 #include "TankControllerLib.h"
 
 unittest(test) {
   TankControllerLib* tc = TankControllerLib::instance();
+  EEPROM_TC::instance()->setPH(7.125);
   SetPHSetPoint* test = new SetPHSetPoint(tc);
+  assertEqual(7.125, PHControl::instance()->getTargetPh());
   tc->setNextState(test, true);
 
   // setValue
   test->setValue(7.1234);
+  assertEqual(7.1234, PHControl::instance()->getTargetPh());
   assertEqual(7.1234, EEPROM_TC::instance()->getPH());
 
   // during the delay we showed the new value


### PR DESCRIPTION
* Update pH control each loop
* Refactor PHControl
  * use a singleton
  * save and retrieve target in EEPROM
  * add some debugging
* MainMenu idle loop now shows actual pH target
* SetPHSetPoint UI State now assigns to PHControl singleton instead of EEPROM
* Update tests to match new design