### PR TITLE
Stop control when doing calibration (fix #102)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -111,6 +111,7 @@ setpoint
 shutil
 sizeof
 snprintf
+solonoids
 src
 strcpy
 strlen

--- a/src/TankControllerLib.h
+++ b/src/TankControllerLib.h
@@ -15,6 +15,7 @@ public:
   void loop();
   void serialEvent();
   void serialEvent1();
+  void setCalibrationMode(bool flag);
   void setNextState(UIState* newState, bool update = false);
   void setup();
   const char* stateName();
@@ -26,6 +27,7 @@ private:
   static const int IDLE_TIMEOUT = 60 * 1000;  // revert to the main menu after 60 seconds of inactivity
 
   // instance variables
+  bool calibrationMode = false;
   UIState* state = nullptr;
   UIState* nextState = nullptr;
   LiquidCrystal_TC* lcd;
@@ -37,5 +39,6 @@ private:
   ~TankControllerLib();
   void blink();
   void handleUI();
+  void updateControls();
   void updateState();
 };

--- a/src/UIState/SeeDeviceUptime.cpp
+++ b/src/UIState/SeeDeviceUptime.cpp
@@ -21,8 +21,4 @@ void SeeDeviceUptime::loop() {
   LiquidCrystal_TC::instance()->writeLine(DateTime_TC::now().as16CharacterString(), 0);
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
   COUT(buffer);
-  if (msEnd < millis()) {
-    COUT("done");
-    returnToMainMenu();
-  }
 }

--- a/src/UIState/SeeDeviceUptime.h
+++ b/src/UIState/SeeDeviceUptime.h
@@ -14,10 +14,4 @@ public:
   const char* name() {
     return "SeeDeviceUptime";
   }
-  void start() {
-    msEnd = millis() + 5000;
-  }
-
-private:
-  int msEnd;
 };

--- a/test/Menu.cpp
+++ b/test/Menu.cpp
@@ -20,6 +20,7 @@ void enterKey(char key) {
 }
 
 unittest_setup() {
+  tc->setCalibrationMode(false);
   TempProbe_TC::instance()->setTemperature(12.25);
   TemperatureControl::enableHeater(true);
   TemperatureControl::instance()->setTargetTemperature(15.75);
@@ -27,6 +28,7 @@ unittest_setup() {
 }
 
 unittest_teardown() {
+  tc->setCalibrationMode(false);
   enterKey('D');
 }
 
@@ -90,9 +92,26 @@ unittest(ViewTime) {
   enterKey('6');
   assertEqual(DateTime_TC::now().as16CharacterString(), lc->getLines().at(0).c_str());
   delay(6000);
-  tc->loop();  // this will set MainMenu as the next state
-  tc->loop();  // this will start MainMenu
+  tc->loop();
+  tc->loop();
+  assertEqual("SeeDeviceUptime", tc->stateName());
+  delay(55000);  // idle timeout should return to main menu
+  tc->loop();
+  tc->loop();
   assertEqual("MainMenu", tc->stateName());
+}
+
+unittest(DisableTimeout) {
+  tc->setCalibrationMode(true);
+  enterKey('8');
+  enterKey('6');
+  enterKey('6');
+  assertEqual("SeeDeviceUptime", tc->stateName());
+  delay(65000);  // 60-second delay does not return to main menu
+  tc->loop();
+  tc->loop();
+  assertEqual("SeeDeviceUptime", tc->stateName());
+  tc->setCalibrationMode(false);
 }
 
 unittest_main()

--- a/test/SeeDeviceUptime.cpp
+++ b/test/SeeDeviceUptime.cpp
@@ -36,10 +36,9 @@ unittest(testWaitState) {
   delay(1000);
   tc->loop();
   assertEqual("Up d:01 02:03:09", display->getLines().at(1));
-  tc->loop();  // SeeDeviceUptime nextState: MainMenu
-  tc->loop();  // SeeDeviceUptime -> MainMenu
-  // now we should be back to the main menu
-  assertEqual("MainMenu", tc->stateName());
+  delay(1000);
+  tc->loop();
+  assertEqual("Up d:01 02:03:10", display->getLines().at(1));
 }
 
 unittest_main()

--- a/test/TCLibTest.cpp
+++ b/test/TCLibTest.cpp
@@ -1,0 +1,87 @@
+#include <Arduino.h>
+#include <ArduinoUnitTests.h>
+
+#include "Devices/PHProbe.h"
+#include "PHControl.h"
+#include "TankControllerLib.h"
+#include "TempProbe_TC.h"
+#include "TemperatureControl.h"
+
+const int TEMP_PIN = 47;
+const int PH_PIN = 49;
+
+GodmodeState *state = GODMODE();
+TankControllerLib *pTC = TankControllerLib::instance();
+TempProbe_TC *tempProbe = TempProbe_TC::instance();
+TemperatureControl *tempControl = TemperatureControl::instance();
+PHProbe *pPHProbe = PHProbe::instance();
+PHControl *pPHControl = PHControl::instance();
+
+unittest_setup() {
+  pTC->setCalibrationMode(false);
+}
+
+unittest_teardown() {
+  pTC->setCalibrationMode(false);
+}
+
+unittest(test) {
+  // set temperature
+  tempProbe->setTemperature(20.0);
+  tempProbe->setCorrection(0.0);
+  for (int i = 0; i < 100; ++i) {
+    tempProbe->getRunningAverage();
+  }
+  assertEqual(20, (int)tempProbe->getRunningAverage());
+
+  // set target temperature
+  tempControl->setTargetTemperature(20.0);
+
+  // set pH
+  state->serialPort[1].dataIn = "7.5\r";  // the queue of data waiting to be read
+  pTC->serialEvent1();                    // fake interrupt
+  assertEqual(7.5, pPHProbe->getPh());
+
+  // set target pH
+  pPHControl->setUsePID(false);
+  pPHControl->setTargetPh(7.5);
+
+  // verify that solonoids are off
+  pTC->loop();
+  assertEqual(HIGH, state->digitalPin[TEMP_PIN]);
+  assertEqual(HIGH, state->digitalPin[PH_PIN]);
+
+  // change targets
+  tempControl->setTargetTemperature(21.0);
+  pPHControl->setTargetPh(7.4);
+  // verify that solonoids are on
+  pTC->loop();
+  delay(10);
+  pTC->loop();
+  assertEqual(LOW, state->digitalPin[TEMP_PIN]);
+  assertEqual(LOW, state->digitalPin[PH_PIN]);
+
+  // reset targets
+  tempControl->setTargetTemperature(19.0);
+  pPHControl->setTargetPh(7.6);
+  // verify that solonoids are off
+  pTC->loop();
+  delay(10);
+  pTC->loop();
+  assertEqual(HIGH, state->digitalPin[TEMP_PIN]);
+  assertEqual(HIGH, state->digitalPin[PH_PIN]);
+
+  pTC->setCalibrationMode(true);
+  // change targets
+  tempControl->setTargetTemperature(21.0);
+  pPHControl->setTargetPh(7.4);
+  // verify that solonoids remain off
+  pTC->loop();
+  delay(10);
+  pTC->loop();
+  assertEqual(HIGH, state->digitalPin[TEMP_PIN]);
+  assertEqual(HIGH, state->digitalPin[PH_PIN]);
+  pTC->setCalibrationMode(false);
+}
+
+unittest_main()

--- a/test/TempProbe_TC_Test.cpp
+++ b/test/TempProbe_TC_Test.cpp
@@ -1,4 +1,4 @@
-#include <TempProbe_TC.h>
+#include "TempProbe_TC.h"
 
 #include "Arduino.h"
 #include "ArduinoUnitTests.h"


### PR DESCRIPTION
Also, don't return to idle menu after 60 seconds.