### PR TITLE
Replace `int` with `int16_t` or variations

### DIFF
--- a/GUI/libTC.cpp
+++ b/GUI/libTC.cpp
@@ -35,12 +35,12 @@
 
 namespace py = pybind11;
 char lcdLine[17];
-unsigned long msOffset = 0;
+uint32_t msOffset = 0;
 std::queue<string> paths;
 
 // function prototypes
 void loop();
-unsigned long millisecondsSinceEpoch();
+uint32_t millisecondsSinceEpoch();
 
 char *dateTime() {
   return DateTime_TC::now().as16CharacterString();
@@ -101,12 +101,12 @@ void key(char key) {
   Keypad_TC::instance()->_getPuppet()->push_back(key);
 }
 
-const char *lcd(int index) {
+const char *lcd(uint16_t index) {
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   String line = lines.at(index);
-  int size = line.size();
+  uint16_t size = line.size();
   assert(size <= 16);
-  for (int i = 0; i < size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     if (line.at(i) < 32) {
       line.at(i) = '?';
     }
@@ -122,14 +122,14 @@ float getTemperature() {
 }
 
 void loop() {
-  int msBehind = millisecondsSinceEpoch() - millis() - msOffset;
+  int32_t msBehind = millisecondsSinceEpoch() - millis() - msOffset;
   if (msBehind) {
     delay(msBehind);
   }
   TankControllerLib::instance()->loop();
 }
 
-unsigned long millisecondsSinceEpoch() {
+uint32_t millisecondsSinceEpoch() {
   return std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
 }
 
@@ -137,11 +137,11 @@ float readPH() {
   return PHProbe::instance()->getPh();
 }
 
-bool readPin(int pin) {
+bool readPin(uint16_t pin) {
   return digitalRead(pin);
 }
 
-string readSerial(int port) {
+string readSerial(uint16_t port) {
   GodmodeState *state = GODMODE();
   string result = string(state->serialPort[port].dataOut);
   state->serialPort[port].dataOut = "";

--- a/src/Devices/DateTime_TC.cpp
+++ b/src/Devices/DateTime_TC.cpp
@@ -70,7 +70,7 @@ void DateTime_TC::yearMonthAsPath(char *buffer, size_t sizeOfBuffer) {
   buffer[0] = '/';
   itoa(year(), buffer + 1, 10);
   buffer[5] = '/';
-  int i = 6;
+  uint16_t i = 6;
   if (month() < 10) {
     buffer[i++] = '0';
   }

--- a/src/Devices/EEPROM_TC.cpp
+++ b/src/Devices/EEPROM_TC.cpp
@@ -21,7 +21,7 @@ EEPROM_TC* EEPROM_TC::instance() {
 }
 
 //  instance methods
-float EEPROM_TC::eepromReadFloat(int address) {
+float EEPROM_TC::eepromReadFloat(uint16_t address) {
   assert(address >= 0);
   float value = 0.0;
   byte* p = (byte*)(void*)&value;
@@ -31,7 +31,7 @@ float EEPROM_TC::eepromReadFloat(int address) {
   return value;
 }
 
-void EEPROM_TC::eepromWriteFloat(int address, float value) {
+void EEPROM_TC::eepromWriteFloat(uint16_t address, float value) {
   assert(address >= 0);
   byte* p = (byte*)(void*)&value;
   for (size_t i = 0; i < sizeof(value); i++) {
@@ -39,9 +39,9 @@ void EEPROM_TC::eepromWriteFloat(int address, float value) {
   }
 }
 
-int EEPROM_TC::eepromReadInt(int address) {
+int32_t EEPROM_TC::eepromReadInt(uint16_t address) {
   assert(address >= 0);
-  int value = 0.0;
+  int32_t value = 0;
   byte* p = (byte*)(void*)&value;
   for (size_t i = 0; i < sizeof(value); i++) {
     *p++ = EEPROM.read(address++);
@@ -49,7 +49,7 @@ int EEPROM_TC::eepromReadInt(int address) {
   return value;
 }
 
-void EEPROM_TC::eepromWriteInt(int address, int value) {
+void EEPROM_TC::eepromWriteInt(uint16_t address, int32_t value) {
   assert(address >= 0);
   byte* p = (byte*)(void*)&value;
   for (size_t i = 0; i < sizeof(value); i++) {
@@ -67,7 +67,7 @@ float EEPROM_TC::getCorrectedTemp() {
 float EEPROM_TC::getFrequency() {
   return eepromReadFloat(FREQUENCY_ADDRESS);
 }
-int EEPROM_TC::getGoogleSheetInterval() {
+uint16_t EEPROM_TC::getGoogleSheetInterval() {
   return eepromReadInt(GOOGLE_INTERVAL_ADDRESS);
 }
 float EEPROM_TC::getGranularity() {
@@ -106,8 +106,8 @@ float EEPROM_TC::getPHSeriesPointer() {
 float EEPROM_TC::getPHSeriesSize() {
   return eepromReadFloat(PH_SERIES_SIZE_ADDRESS);
 }
-int EEPROM_TC::getTankID() {
-  return static_cast<int>(eepromReadFloat(TANK_ID_ADDRESS));
+uint16_t EEPROM_TC::getTankID() {
+  return static_cast<uint16_t>(eepromReadFloat(TANK_ID_ADDRESS));
 }
 float EEPROM_TC::getTemp() {
   return eepromReadFloat(TEMP_ADDRESS);
@@ -134,7 +134,7 @@ void EEPROM_TC::setCorrectedTemp(float value) {
 void EEPROM_TC::setFrequency(float value) {
   eepromWriteFloat(FREQUENCY_ADDRESS, value);
 }
-void EEPROM_TC::setGoogleSheetInterval(int value) {
+void EEPROM_TC::setGoogleSheetInterval(uint16_t value) {
   eepromWriteInt(GOOGLE_INTERVAL_ADDRESS, value);
 }
 void EEPROM_TC::setGranularity(float value) {
@@ -173,7 +173,7 @@ void EEPROM_TC::setPHSeriesPointer(float value) {
 void EEPROM_TC::setPHSeriesSize(float value) {
   eepromWriteFloat(PH_SERIES_SIZE_ADDRESS, value);
 }
-void EEPROM_TC::setTankID(int value) {
+void EEPROM_TC::setTankID(uint16_t value) {
   eepromWriteFloat(TANK_ID_ADDRESS, (float)value);
 }
 void EEPROM_TC::setTemp(float value) {

--- a/src/Devices/EEPROM_TC.h
+++ b/src/Devices/EEPROM_TC.h
@@ -1,22 +1,23 @@
 #pragma once
 
 #include "Devices/EEPROM_TC.h"
+#include "TC_util.h"
 
 class EEPROM_TC {
 public:
   static EEPROM_TC* instance();
 
   // read and write
-  float eepromReadFloat(int address);
-  int eepromReadInt(int address);
-  void eepromWriteFloat(int address, float value);
-  void eepromWriteInt(int address, int value);
+  float eepromReadFloat(uint16_t address);
+  int32_t eepromReadInt(uint16_t address);
+  void eepromWriteFloat(uint16_t address, float value);
+  void eepromWriteInt(uint16_t address, int32_t value);
 
   // accessor methods
   float getAmplitude();
   float getCorrectedTemp();
   float getFrequency();
-  int getGoogleSheetInterval();
+  uint16_t getGoogleSheetInterval();
   float getGranularity();
   bool getHeat();
   float getKD();
@@ -29,7 +30,7 @@ public:
   float getPHInterval();
   float getPHSeriesPointer();
   float getPHSeriesSize();
-  int getTankID();
+  uint16_t getTankID();
   float getTemp();
   float getTempDelay();
   float getTempInterval();
@@ -40,7 +41,7 @@ public:
   void setAmplitude(float value);
   void setCorrectedTemp(float value);
   void setFrequency(float value);
-  void setGoogleSheetInterval(int value);
+  void setGoogleSheetInterval(uint16_t value);
   void setGranularity(float value);
   void setHeat(bool value);
   void setKD(float value);
@@ -53,7 +54,7 @@ public:
   void setPHInterval(float value);
   void setPHSeriesPointer(float value);
   void setPHSeriesSize(float value);
-  void setTankID(int value);
+  void setTankID(uint16_t value);
   void setTemp(float value);
   void setTempDelay(float value);
   void setTempInterval(float value);
@@ -64,30 +65,30 @@ public:
 
 private:
   // instance variables from v0.197
-  const int PH_ADDRESS = 0;          // 9.999
-  const int TEMP_ADDRESS = 4;        // 99.99
-  const int TANK_ID_ADDRESS = 8;     // 999
-  const int TEMP_CORR_ADDRESS = 12;  // 99.99
-  const int KP_ADDRESS = 20;         // float
-  const int KI_ADDRESS = 28;         // float
-  const int KD_ADDRESS = 36;         // float
-  const int MAC_ADDRESS = 44;        // 8 byte
-  const int HEAT_ADDRESS = 52;       // bool
+  const uint16_t PH_ADDRESS = 0;          // 9.999
+  const uint16_t TEMP_ADDRESS = 4;        // 99.99
+  const uint16_t TANK_ID_ADDRESS = 8;     // 999
+  const uint16_t TEMP_CORR_ADDRESS = 12;  // 99.99
+  const uint16_t KP_ADDRESS = 20;         // float
+  const uint16_t KI_ADDRESS = 28;         // float
+  const uint16_t KD_ADDRESS = 36;         // float
+  const uint16_t MAC_ADDRESS = 44;        // 8 byte
+  const uint16_t HEAT_ADDRESS = 52;       // bool
   // new with v0.2
-  const int AMPLITUDE_ADDRESS = 56;
-  const int FREQUENCY_ADDRESS = 60;
-  const int GRANULARITY_ADDRESS = 64;   // granularity for SD logging interval
-  const int MAX_DATA_AGE_ADDRESS = 68;  // max data age for SD card
-  const int PH_SERIES_SIZE_ADDRESS = 72;
-  const int PH_SERIES_POINTER_ADDRESS = 76;
-  const int TEMP_SERIES_SIZE_ADDRESS = 80;
-  const int TEMP_SERIES_POINTER_ADDRESS = 84;
-  const int PH_INTERVAL_ADDRESS = 88;
-  const int PH_DELAY_ADDRESS = 92;
-  const int TEMP_INTERVAL_ADDRESS = 96;
-  const int TEMP_DELAY_ADDRESS = 100;
+  const uint16_t AMPLITUDE_ADDRESS = 56;
+  const uint16_t FREQUENCY_ADDRESS = 60;
+  const uint16_t GRANULARITY_ADDRESS = 64;   // granularity for SD logging interval
+  const uint16_t MAX_DATA_AGE_ADDRESS = 68;  // max data age for SD card
+  const uint16_t PH_SERIES_SIZE_ADDRESS = 72;
+  const uint16_t PH_SERIES_POINTER_ADDRESS = 76;
+  const uint16_t TEMP_SERIES_SIZE_ADDRESS = 80;
+  const uint16_t TEMP_SERIES_POINTER_ADDRESS = 84;
+  const uint16_t PH_INTERVAL_ADDRESS = 88;
+  const uint16_t PH_DELAY_ADDRESS = 92;
+  const uint16_t TEMP_INTERVAL_ADDRESS = 96;
+  const uint16_t TEMP_DELAY_ADDRESS = 100;
   // new with v0.3
-  const int GOOGLE_INTERVAL_ADDRESS = 108;
+  const uint16_t GOOGLE_INTERVAL_ADDRESS = 108;
 
   // class variables
   static EEPROM_TC* _instance;

--- a/src/Devices/Ethernet_TC.cpp
+++ b/src/Devices/Ethernet_TC.cpp
@@ -21,7 +21,7 @@ Ethernet_TC *Ethernet_TC::instance() {
 }
 
 void Ethernet_TC::renewDHCPLease() {
-  unsigned long current_millis = millis();
+  uint32_t current_millis = millis();
   if ((current_millis - previous_lease) >= LEASE_INTERVAL || current_millis < previous_lease) {
     Ethernet.maintain();
     previous_lease = current_millis;

--- a/src/Devices/Ethernet_TC.h
+++ b/src/Devices/Ethernet_TC.h
@@ -16,7 +16,7 @@ public:
   byte *getMac() {
     return mac;
   }
-  int getNumAttemptedDHCPReleases() {
+  uint16_t getNumAttemptedDHCPReleases() {
     return numAttemptedDHCPReleases;
   };
   void renewDHCPLease();
@@ -33,9 +33,9 @@ private:
   IPAddress defaultIP = IPAddress(192, 168, 1, 2);
   IPAddress time_serverIP;
   IPAddress IP;
-  unsigned long previous_lease = 0;
-  const unsigned long LEASE_INTERVAL = 345600000;  // 4 days in milliseconds
+  uint32_t previous_lease = 0;
+  const uint32_t LEASE_INTERVAL = 345600000;  // 4 days in milliseconds
 
   // testing
-  int numAttemptedDHCPReleases = 0;
+  uint16_t numAttemptedDHCPReleases = 0;
 };

--- a/src/Devices/LiquidCrystal_TC.cpp
+++ b/src/Devices/LiquidCrystal_TC.cpp
@@ -6,7 +6,7 @@
 #include "TC_util.h"
 
 // pins used for our LiquidDisplay
-const int RS = 24, EN = 22, D4 = 26, D5 = 28, D6 = 30, D7 = 32;
+const uint16_t RS = 24, EN = 22, D4 = 26, D5 = 28, D6 = 30, D7 = 32;
 
 //  class variables
 LiquidCrystal_TC* LiquidCrystal_TC::_instance = nullptr;
@@ -87,12 +87,12 @@ void LiquidCrystal_TC::splashScreen() {
  * Prints an input string to the desired line of the LCD screen
  * Even numbers go on the bottom line, odd ones go on the top line
  */
-void LiquidCrystal_TC::writeLine(const char* text, int line) {
+void LiquidCrystal_TC::writeLine(const char* text, uint16_t line) {
   line = line % 2;
   setCursor(0, line);
   char result[17];
   bool moreText = true;
-  for (int i = 0; i < 16; i++) {
+  for (size_t i = 0; i < 16; i++) {
     if (moreText && text[i] == '\0') {
       moreText = false;
     }

--- a/src/Devices/LiquidCrystal_TC.h
+++ b/src/Devices/LiquidCrystal_TC.h
@@ -10,7 +10,7 @@
 class LiquidCrystal_TC : public LiquidCrystal {
 public:
   static LiquidCrystal_TC* instance();
-  void writeLine(const char* text, int line);
+  void writeLine(const char* text, uint16_t line);
 
 private:
   // class variables

--- a/src/Devices/PHControl.cpp
+++ b/src/Devices/PHControl.cpp
@@ -82,7 +82,7 @@ void PHControl::updateControl(float pH) {
   if (newValue != pinValue) {
     pinValue = newValue;
     DateTime_TC::now().printToSerial();
-    unsigned long currentMS = millis();
+    uint32_t currentMS = millis();
     serial("CO2 bubbler turned %s after %lu ms", pinValue ? "off" : "on", currentMS - lastSwitchMS);
     lastSwitchMS = currentMS;
     digitalWrite(PIN, pinValue);

--- a/src/Devices/PHControl.h
+++ b/src/Devices/PHControl.h
@@ -5,11 +5,11 @@ private:
   // Class variable
   static PHControl* _instance;
   // instance variables
-  unsigned long lastSwitchMS = 0;
-  const int PIN = 49;
-  const int SOLENOID_OPENING_TIME = 100;
+  uint32_t lastSwitchMS = 0;
+  const uint16_t PIN = 49;
+  const uint16_t SOLENOID_OPENING_TIME = 100;
   float targetPh;
-  const int WINDOW_SIZE = 10000;  // 10 second Time Proportional output window
+  const uint16_t WINDOW_SIZE = 10000;  // 10 second Time Proportional output window
   long onTime = 0;
   long window_start_time;
   bool usePID = true;

--- a/src/Devices/PID_TC.h
+++ b/src/Devices/PID_TC.h
@@ -17,7 +17,7 @@ public:
   float getKp() {
     return pPID->GetKp();
   }
-  int getMode() {
+  uint16_t getMode() {
     return pPID->GetMode();
   }
   void logToSerial();
@@ -37,6 +37,6 @@ private:
   double input = 0.0;
   double output = 0.0;
   double set_point = 0.0;
-  const int WINDOW_SIZE = 10000;
+  const uint16_t WINDOW_SIZE = 10000;
   PID *pPID;
 };

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -119,7 +119,7 @@ void SD_TC::visit(visitor pFunction) {
 }
 
 void SD_TC::visit(visitor pFunction, File* pDir, String parentPath) {
-  int i = 0;
+  uint16_t i = 0;
   while (i++ < 100) {
     File entry = pDir->openNextFile();
     if (!entry) {

--- a/src/Devices/SD_TC.h
+++ b/src/Devices/SD_TC.h
@@ -26,8 +26,8 @@ private:
   static SD_TC* _instance;
 
   // instance variables
-  const int IO_PIN = 10;
-  const int SELECT_PIN = 4;
+  const uint16_t IO_PIN = 10;
+  const uint16_t SELECT_PIN = 4;
   bool hasHadError = false;
 
   // instance methods

--- a/src/Devices/TempProbe_TC.cpp
+++ b/src/Devices/TempProbe_TC.cpp
@@ -53,11 +53,11 @@ TempProbe_TC::TempProbe_TC() {
  * Do this only once per second since device is unreliable beyond that.
  */
 float TempProbe_TC::getRunningAverage() {
-  unsigned long currentTime = millis();
+  uint32_t currentTime = millis();
   if (firstTime || lastTime + 1000 <= currentTime) {
     float temp = this->getRawTemperature();
     if (firstTime) {
-      for (int i = 0; i < HISTORY_SIZE; ++i) {
+      for (size_t i = 0; i < HISTORY_SIZE; ++i) {
         history[i] = temp;
       }
       firstTime = false;
@@ -67,7 +67,7 @@ float TempProbe_TC::getRunningAverage() {
     lastTime = currentTime;
   }
   float sum = 0.0;
-  for (int i = 0; i < HISTORY_SIZE; ++i) {
+  for (size_t i = 0; i < HISTORY_SIZE; ++i) {
     sum += history[i];
   }
   return sum / HISTORY_SIZE + correction;

--- a/src/Devices/TempProbe_TC.h
+++ b/src/Devices/TempProbe_TC.h
@@ -123,15 +123,15 @@ private:
   static TempProbe_TC* _instance;
 
   //  Instance variables
-  static const int RTDnominal = 100;
-  static const int refResistor = 430;
+  static const uint16_t RTDnominal = 100;
+  static const uint16_t refResistor = 430;
   Adafruit_MAX31865 thermo = Adafruit_MAX31865(45, 43, 41, 39);
   bool firstTime = true;
-  static const int HISTORY_SIZE = 10;
+  static const uint16_t HISTORY_SIZE = 10;
   float history[HISTORY_SIZE];
-  int historyIndex = 0;
+  uint16_t historyIndex = 0;
   float correction = 0.0;
-  unsigned long lastTime = 0;
+  uint32_t lastTime = 0;
 
   // Methods
   TempProbe_TC();

--- a/src/Devices/TemperatureControl.cpp
+++ b/src/Devices/TemperatureControl.cpp
@@ -75,7 +75,7 @@ void TemperatureControl::setTargetTemperature(float newTemperature) {
 }
 
 void Chiller::updateControl(float currentTemperature) {
-  unsigned long currentMillis = millis();
+  uint32_t currentMillis = millis();
   // pause 30 seconds between switching chiller on and off to prevent damage to chiller
   if (currentMillis - previousMillis >= TIME_INTERVAL) {
     bool newValue = pinValue;
@@ -95,7 +95,7 @@ void Chiller::updateControl(float currentTemperature) {
     if (newValue != pinValue) {
       pinValue = newValue;
       DateTime_TC::now().printToSerial();
-      unsigned long currentMS = millis();
+      uint32_t currentMS = millis();
       serial("chiller turned %s after %lu ms", pinValue ? "off" : "on", currentMS - lastSwitchMS);
       lastSwitchMS = currentMS;
       digitalWrite(PIN, pinValue);
@@ -120,7 +120,7 @@ void Heater::updateControl(float currentTemperature) {
   if (newValue != pinValue) {
     pinValue = newValue;
     DateTime_TC::now().printToSerial();
-    unsigned long currentMS = millis();
+    uint32_t currentMS = millis();
     serial("heater turned %s after %lu ms", pinValue ? "off" : "on", currentMS - lastSwitchMS);
     lastSwitchMS = currentMS;
     digitalWrite(PIN, pinValue);

--- a/src/Devices/TemperatureControl.h
+++ b/src/Devices/TemperatureControl.h
@@ -11,9 +11,9 @@ private:
   static TemperatureControl* _instance;
 
 protected:
-  const int PIN = 47;
+  const uint16_t PIN = 47;
   const float DELTA = 0.05;
-  unsigned long lastSwitchMS = 0;
+  uint32_t lastSwitchMS = 0;
   float targetTemperature;
   bool pinValue = HIGH;
   TemperatureControl();
@@ -42,8 +42,8 @@ public:
 
 class Chiller : public TemperatureControl {
 private:
-  const unsigned long TIME_INTERVAL = 30 * 1000UL;  // interval at which to change chiller state
-  unsigned long previousMillis = 0;                 // will store last time chiller state was checked
+  const uint32_t TIME_INTERVAL = 30 * 1000UL;  // interval at which to change chiller state
+  uint32_t previousMillis = 0;                 // will store last time chiller state was checked
 
 public:
   Chiller() : TemperatureControl(){};

--- a/src/TankControllerLib.cpp
+++ b/src/TankControllerLib.cpp
@@ -210,22 +210,22 @@ const char *TankControllerLib::version() {
  * once per second write the current data to the SD card
  */
 void TankControllerLib::writeDataToSD() {
-  static unsigned long nextWriteTime = 0;
+  static uint32_t nextWriteTime = 0;
   static const char header[] = "time,tankid,temp,temp setpoint,pH,pH setpoint,onTime,Kp,Ki,Kd";
   static const char format[] =
       "%02i/%02i/%4i %02i:%02i:%02i, %3i, %2.3f, %2.3f, %1.4f, %1.4f, %4i, %5.1f, %5.1f, %5.1f";
-  unsigned long msNow = millis();
+  uint32_t msNow = millis();
   COUT("nextWriteTime: " << nextWriteTime << "; now = " << msNow);
   if (nextWriteTime <= msNow) {
     char buffer[128];
     DateTime_TC dtNow = DateTime_TC::now();
     PID_TC *pPID = PID_TC::instance();
-    int tankId = 0;
-    snprintf(buffer, sizeof(buffer), format, (int)dtNow.month(), (int)dtNow.day(), (int)dtNow.year(), (int)dtNow.hour(),
-             (int)dtNow.minute(), (int)dtNow.second(), (int)tankId,
+    uint16_t tankId = 0;
+    snprintf(buffer, sizeof(buffer), format, (uint16_t)dtNow.month(), (uint16_t)dtNow.day(), (uint16_t)dtNow.year(),
+             (uint16_t)dtNow.hour(), (uint16_t)dtNow.minute(), (uint16_t)dtNow.second(), (uint16_t)tankId,
              (float)TempProbe_TC::instance()->getRunningAverage(),
              (float)TemperatureControl::instance()->getTargetTemperature(), (float)PHProbe::instance()->getPh(),
-             (float)PHControl::instance()->getTargetPh(), (int)0, (float)pPID->getKp(), (float)pPID->getKi(),
+             (float)PHControl::instance()->getTargetPh(), (uint16_t)0, (float)pPID->getKp(), (float)pPID->getKi(),
              (float)pPID->getKd());  // still missing onTime
     SD_TC::instance()->appendData(header, buffer);
     nextWriteTime = msNow / 1000 * 1000 + 1000;  // round up to next second

--- a/src/TankControllerLib.h
+++ b/src/TankControllerLib.h
@@ -28,12 +28,12 @@ public:
 private:
   // class variables
   static TankControllerLib* _instance;
-  static const unsigned long IDLE_TIMEOUT = 60L * 1000L;  // revert to the main menu after 60 seconds of inactivity
+  static const uint32_t IDLE_TIMEOUT = 60L * 1000L;  // revert to the main menu after 60 seconds of inactivity
 
   // instance variables
   UIState* state = nullptr;
   UIState* nextState = nullptr;
-  unsigned long lastKeypadTime = 0;
+  uint32_t lastKeypadTime = 0;
 
   // instance methods
   TankControllerLib();

--- a/src/UIState/EnablePID.cpp
+++ b/src/UIState/EnablePID.cpp
@@ -15,7 +15,7 @@ void EnablePID::setValue(float value) {
   if (!(value == 1.0 || value == 9.0)) {
     LiquidCrystal_TC::instance()->writeLine("Invalid entry!  ", 1);
   } else {
-    bool flag = (int)value == 1;
+    bool flag = (uint16_t)value == 1;
     PHControl::instance()->enablePID(flag);
     if (flag) {
       LiquidCrystal_TC::instance()->writeLine("PID enabled     ", 1);

--- a/src/UIState/MainMenu.h
+++ b/src/UIState/MainMenu.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "TC_util.h"
 #include "UIState.h"
 
 class TankControllerLib;  // forward reference
@@ -54,8 +55,8 @@ public:
   void loop();
 
 private:
-  int level1 = 0;
-  int level2 = -1;
+  int16_t level1 = 0;
+  int16_t level2 = -1;
   String viewMenus[VIEW_COMMAND_COUNT];
   String setMenus[SET_COMMAND_COUNT];
   void left();

--- a/src/UIState/NumberCollectorState.cpp
+++ b/src/UIState/NumberCollectorState.cpp
@@ -32,7 +32,7 @@ void NumCollectorState::handleKey(char key) {
   printValue();
 }
 
-void NumCollectorState::handleDigit(int digit) {
+void NumCollectorState::handleDigit(uint16_t digit) {
   if (hasDecimal) {
     value = value + (float)digit / factor;
     factor = factor * 10;
@@ -64,14 +64,14 @@ void NumCollectorState::printValue() {
   if (!hasDecimal) {
     // show user entry as an integer (no decimal yet)
     snprintf(format, sizeof(format), "%s%%6i", strValue);
-    snprintf(strValue, sizeof(strValue), format, (int)value);
+    snprintf(strValue, sizeof(strValue), format, (uint16_t)value);
   } else if (factor == 10) {
     // show user entry with a decimal but nothing beyond
     snprintf(format, sizeof(format), "%s%%6i.", strValue);
-    snprintf(strValue, sizeof(strValue), format, (int)value);
+    snprintf(strValue, sizeof(strValue), format, (uint16_t)value);
   } else {
     // show user entry with appropriate precision (based on digits user has entered)
-    int precision = log10(factor / 10);
+    uint16_t precision = log10(factor / 10);
     snprintf(format, sizeof(format), "%s%%7.%if", strValue, precision);
     snprintf(strValue, sizeof(strValue), format, value);
   }

--- a/src/UIState/NumberCollectorState.h
+++ b/src/UIState/NumberCollectorState.h
@@ -17,19 +17,19 @@ protected:
   // Helper Functions
   void backSpace();
   void clear();
-  void handleDigit(int digit);
+  void handleDigit(uint16_t digit);
   virtual bool isInteger() {
     return false;
   }
   void printValue();
   virtual float getCurrentValue() = 0;
-  virtual int getCurrentValuePrecision() {
+  virtual uint16_t getCurrentValuePrecision() {
     return 0;
   };
 
   float value = 0.0;
-  int numDigits = 0;
-  int factor = 10;
+  uint16_t numDigits = 0;
+  uint16_t factor = 10;
   bool hasDecimal = false;
 };
 
@@ -48,7 +48,7 @@ public:
   float getCurrentValue() {
     return priorValue;
   }
-  int getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() {
     return priorValuePrecision;
   }
   const char* prompt() {
@@ -65,14 +65,14 @@ public:
   void setPriorValue(float aValue) {
     priorValue = aValue;
   }
-  void setPriorValuePrecision(int aValue) {
+  void setPriorValuePrecision(uint16_t aValue) {
     priorValuePrecision = aValue;
   }
 
 private:
   float storedValue = 0.0;
   float priorValue = 0.0;
-  int priorValuePrecision = 0;
+  uint16_t priorValuePrecision = 0;
 };
 
 class TestIntNumCollectorState : public TestNumCollectorState {

--- a/src/UIState/PHCalibrationHigh.h
+++ b/src/UIState/PHCalibrationHigh.h
@@ -19,7 +19,7 @@ public:
   float getCurrentValue() {
     return 0.0;
   }
-  int getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() {
     return 3;
   }
   const char* prompt() {

--- a/src/UIState/PHCalibrationLow.h
+++ b/src/UIState/PHCalibrationLow.h
@@ -19,7 +19,7 @@ public:
   float getCurrentValue() {
     return 0.0;
   }
-  int getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() {
     return 3;
   }
   const char* prompt() {

--- a/src/UIState/PHCalibrationMid.h
+++ b/src/UIState/PHCalibrationMid.h
@@ -19,7 +19,7 @@ public:
   float getCurrentValue() {
     return 0.0;
   }
-  int getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() {
     return 3;
   }
   const char* prompt() {

--- a/src/UIState/SeeDeviceUptime.cpp
+++ b/src/UIState/SeeDeviceUptime.cpp
@@ -9,12 +9,12 @@
 #include "TC_util.h"
 
 void SeeDeviceUptime::loop() {
-  unsigned long ms = millis();
+  uint32_t ms = millis();
   COUT("SeeDeviceUptime::loop() at " << ms);
-  int days = ms / 86400000;
-  int hours = (ms - (days * 86400000)) / 3600000;
-  int minutes = (ms - (days * 86400000) - (hours * 3600000)) / 60000;
-  int seconds = (ms - (days * 86400000) - (hours * 3600000) - (minutes * 60000)) / 1000;
+  uint16_t days = ms / 86400000;
+  uint16_t hours = (ms - (days * 86400000)) / 3600000;
+  uint16_t minutes = (ms - (days * 86400000) - (hours * 3600000)) / 60000;
+  uint16_t seconds = (ms - (days * 86400000) - (hours * 3600000) - (minutes * 60000)) / 1000;
   char buffer[17];
   COUT("days: " << days << "; hours: " << hours << "; mins: " << minutes << "; secs: " << seconds);
   snprintf(buffer, sizeof(buffer), "Up d:%02i %02i:%02i:%02i", days, hours, minutes, seconds);

--- a/src/UIState/SeePIDConstants.cpp
+++ b/src/UIState/SeePIDConstants.cpp
@@ -10,7 +10,7 @@
 #include "TC_util.h"
 
 void SeePIDConstants::loop() {
-  int elapsedSeconds = ((millis() - startTime) / 3000) % 2;
+  int32_t elapsedSeconds = ((millis() - startTime) / 3000) % 2;
   switch (elapsedSeconds) {
     case 0:
       loadKp(0);
@@ -23,19 +23,19 @@ void SeePIDConstants::loop() {
   }
 }
 
-void SeePIDConstants::loadKp(int line) {
+void SeePIDConstants::loadKp(uint16_t line) {
   char buffer[17];
   snprintf(buffer, sizeof(buffer), "Kp: %.1f", PID_TC::instance()->getKp());
   LiquidCrystal_TC::instance()->writeLine(buffer, line);
 }
 
-void SeePIDConstants::loadKi(int line) {
+void SeePIDConstants::loadKi(uint16_t line) {
   char buffer[17];
   snprintf(buffer, sizeof(buffer), "Ki: %.1f", PID_TC::instance()->getKi());
   LiquidCrystal_TC::instance()->writeLine(buffer, line);
 }
 
-void SeePIDConstants::loadKd(int line) {
+void SeePIDConstants::loadKd(uint16_t line) {
   char buffer[17];
   snprintf(buffer, sizeof(buffer), "Kd: %.1f", PID_TC::instance()->getKd());
   LiquidCrystal_TC::instance()->writeLine(buffer, line);

--- a/src/UIState/SeePIDConstants.h
+++ b/src/UIState/SeePIDConstants.h
@@ -4,6 +4,7 @@
  * See PID Constants
  */
 #pragma once
+#include "TC_util.h"
 #include "UIState.h"
 
 class SeePIDConstants : public UIState {
@@ -19,10 +20,10 @@ public:
   }
 
 private:
-  void loadKp(int line);
-  void loadKi(int line);
-  void loadKd(int line);
-  void loadSlope(int line);
+  void loadKp(uint16_t line);
+  void loadKi(uint16_t line);
+  void loadKd(uint16_t line);
+  void loadSlope(uint16_t line);
 
-  unsigned long startTime;
+  uint32_t startTime;
 };

--- a/src/UIState/SetChillOrHeat.cpp
+++ b/src/UIState/SetChillOrHeat.cpp
@@ -11,7 +11,7 @@ void SetChillOrHeat::setValue(float value) {
   if (!(value == 1.0 || value == 9.0)) {
     LiquidCrystal_TC::instance()->writeLine("Invalid entry!  ", 1);
   } else {
-    bool isHeat = (int)value == 9;
+    bool isHeat = (uint16_t)value == 9;
     TemperatureControl::instance()->enableHeater(isHeat);
     if (isHeat) {
       LiquidCrystal_TC::instance()->writeLine("Use heater      ", 1);

--- a/src/UIState/SetGoogleSheetInterval.cpp
+++ b/src/UIState/SetGoogleSheetInterval.cpp
@@ -8,10 +8,10 @@
 #include "Devices/LiquidCrystal_TC.h"
 
 void SetGoogleSheetInterval::setValue(float value) {
-  EEPROM_TC::instance()->setGoogleSheetInterval((int)value);
+  EEPROM_TC::instance()->setGoogleSheetInterval((uint16_t)value);
 
   char output[17];
-  snprintf(output, sizeof(output), "New interval=%i", (int)value);
+  snprintf(output, sizeof(output), "New interval=%i", (uint16_t)value);
   LiquidCrystal_TC::instance()->writeLine(output, 1);
   returnToMainMenu(1000);  // after 1-second delay
 }

--- a/src/UIState/SetKD.h
+++ b/src/UIState/SetKD.h
@@ -16,7 +16,7 @@ public:
   float getCurrentValue() {
     return 0.0;
   }
-  int getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() {
     return 1;
   }
   const char* prompt() {

--- a/src/UIState/SetKI.h
+++ b/src/UIState/SetKI.h
@@ -16,7 +16,7 @@ public:
   float getCurrentValue() {
     return 0.0;
   }
-  int getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() {
     return 1;
   }
   const char* prompt() {

--- a/src/UIState/SetKP.h
+++ b/src/UIState/SetKP.h
@@ -16,7 +16,7 @@ public:
   float getCurrentValue() {
     return 0.0;
   }
-  int getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() {
     return 1;
   }
   const char* prompt() {

--- a/src/UIState/SetPHSetPoint.h
+++ b/src/UIState/SetPHSetPoint.h
@@ -14,7 +14,7 @@ public:
     return "SetPHSetPoint";
   }
   float getCurrentValue();
-  int getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() {
     return 3;
   }
   const char* prompt() {

--- a/src/UIState/SetTankID.cpp
+++ b/src/UIState/SetTankID.cpp
@@ -11,7 +11,7 @@ void SetTankID::setValue(float value) {
   EEPROM_TC::instance()->setTankID(value);
 
   char output[17];
-  snprintf(output, sizeof(output), "Tank ID = %i", (int)value);
+  snprintf(output, sizeof(output), "Tank ID = %i", (uint16_t)value);
   LiquidCrystal_TC::instance()->writeLine(output, 1);
   returnToMainMenu(1000);  // after 1-second delay
 }

--- a/src/UIState/SetTempSetPoint.h
+++ b/src/UIState/SetTempSetPoint.h
@@ -16,7 +16,7 @@ public:
   float getCurrentValue() {
     return 0.0;
   }
-  int getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() {
     return 2;
   }
   const char* prompt() {

--- a/src/UIState/SetTime.h
+++ b/src/UIState/SetTime.h
@@ -25,9 +25,9 @@ public:
   void setValue(float value);
 
 private:
-  static const int NUM_VALUES = 5;
-  int subState = 0;
-  int values[NUM_VALUES] = {0, 0, 0, 0, 0};
+  static const uint16_t NUM_VALUES = 5;
+  uint16_t subState = 0;
+  uint16_t values[NUM_VALUES] = {0, 0, 0, 0, 0};
   const char* prompts[NUM_VALUES] = {
       "Set Year (YYYY):", "Month (1-12):   ", "Day (1-31):     ", "Hour (0-23):    ", "Minute (0-59):  "};
 };

--- a/src/UIState/TemperatureCalibration.h
+++ b/src/UIState/TemperatureCalibration.h
@@ -19,7 +19,7 @@ public:
   float getCurrentValue() {
     return 0;
   }
-  int getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() {
     return 2;
   }
   const char* prompt() {

--- a/src/UIState/UIState.cpp
+++ b/src/UIState/UIState.cpp
@@ -15,7 +15,7 @@ void UIState::handleKey(char key) {
   this->returnToMainMenu();
 }
 
-void UIState::returnToMainMenu(int msDelay) {
+void UIState::returnToMainMenu(uint16_t msDelay) {
   if (msDelay) {
     this->setNextState((UIState*)new Wait(tc, msDelay));
   } else {

--- a/src/UIState/UIState.h
+++ b/src/UIState/UIState.h
@@ -36,6 +36,6 @@ public:
 
 protected:
   void setNextState(UIState* state);
-  void returnToMainMenu(int msDelay = 0);
+  void returnToMainMenu(uint16_t msDelay = 0);
   TankControllerLib* tc = nullptr;
 };

--- a/src/UIState/Wait.cpp
+++ b/src/UIState/Wait.cpp
@@ -3,7 +3,7 @@
 #include "MainMenu.h"
 #include "TC_util.h"
 
-Wait::Wait(TankControllerLib *tc, int msDelay, UIState *nextState) : UIState(tc) {
+Wait::Wait(TankControllerLib *tc, uint16_t msDelay, UIState *nextState) : UIState(tc) {
   endTime = millis() + msDelay;
   if (nextState) {
     COUT(nextState->name());

--- a/src/UIState/Wait.h
+++ b/src/UIState/Wait.h
@@ -8,7 +8,7 @@
 
 class Wait : public UIState {
 public:
-  Wait(TankControllerLib* tc, int msDelay = 1000, UIState* nextState = nullptr);
+  Wait(TankControllerLib* tc, uint16_t msDelay = 1000, UIState* nextState = nullptr);
   // watch to see if enough time has passed
   void loop();
   const char* name() {

--- a/test/BlinkTest.cpp
+++ b/test/BlinkTest.cpp
@@ -8,14 +8,14 @@
 #include "TankControllerLib.h"
 
 GodmodeState* state = GODMODE();
-const int LOG_SIZE = 10;
+const uint16_t LOG_SIZE = 10;
 struct {
   long time;
   bool value;
 } pinLog[LOG_SIZE];
-int logIndex = 0;
+uint16_t logIndex = 0;
 bool overflowFlag = false;
-const int LED_PIN = 13;
+const uint16_t LED_PIN = 13;
 
 class BitCollector : public DataStreamObserver {
 public:

--- a/test/EEPROMTest.cpp
+++ b/test/EEPROMTest.cpp
@@ -20,7 +20,7 @@ unittest(singleton) {
 
 unittest(eeprom_Read_and_Write_Double) {
   EEPROM_TC* test = EEPROM_TC::instance();
-  const int TEST_ADDRESS = 4000;  // beyond the end of our use
+  const uint16_t TEST_ADDRESS = 4000;  // beyond the end of our use
 
   // integer
   test->eepromWriteFloat(TEST_ADDRESS, 10);
@@ -47,7 +47,7 @@ unittest(Temp) {
 
 unittest(TankID) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(-2147483648, singleton->getTankID());
+  assertEqual(0, singleton->getTankID());
   singleton->setTankID(5);
   assertEqual(5, singleton->getTankID());
 }
@@ -182,7 +182,7 @@ unittest(TempDelay) {
 
 unittest(GoogleSheetIntervalMinutes) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(-1, singleton->getGoogleSheetInterval());
+  assertEqual(65535, singleton->getGoogleSheetInterval());
   singleton->setGoogleSheetInterval(20);
   assertEqual(20, singleton->getGoogleSheetInterval());
 }

--- a/test/LiquidCrystalTest.cpp
+++ b/test/LiquidCrystalTest.cpp
@@ -18,16 +18,16 @@ unittest(loop) {
   assertEqual(2, lines.size());
   assertEqual(16, lines.at(0).length());
   assertEqual(16, lines.at(1).length());
-  assertEqual(0, (int)lines.at(0).at(0));
-  assertEqual(1, (int)lines.at(0).at(1));
-  assertEqual(2, (int)lines.at(0).at(2));
-  assertEqual(3, (int)lines.at(0).at(3));
-  assertEqual(4, (int)lines.at(1).at(0));
-  assertEqual(5, (int)lines.at(1).at(1));
-  assertEqual(6, (int)lines.at(1).at(2));
-  assertEqual(7, (int)lines.at(1).at(3));
-  for (int i = 0; i < lines.size(); ++i) {
-    for (int j = 0; j < lines.at(i).size(); ++j) {
+  assertEqual(0, (uint16_t)lines.at(0).at(0));
+  assertEqual(1, (uint16_t)lines.at(0).at(1));
+  assertEqual(2, (uint16_t)lines.at(0).at(2));
+  assertEqual(3, (uint16_t)lines.at(0).at(3));
+  assertEqual(4, (uint16_t)lines.at(1).at(0));
+  assertEqual(5, (uint16_t)lines.at(1).at(1));
+  assertEqual(6, (uint16_t)lines.at(1).at(2));
+  assertEqual(7, (uint16_t)lines.at(1).at(3));
+  for (size_t i = 0; i < lines.size(); ++i) {
+    for (size_t j = 0; j < lines.at(i).size(); ++j) {
       if (lines.at(i).at(j) < ' ') {
         lines.at(i).at(j) = '?';
       }

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -8,7 +8,7 @@
 #include "PHControl.h"
 #include "TankControllerLib.h"
 
-const int PIN = 49;
+const uint16_t PIN = 49;
 
 /**
  * cycle the control through to a point of being off

--- a/test/PIDTest.cpp
+++ b/test/PIDTest.cpp
@@ -48,7 +48,7 @@ unittest(compute) {
   assertEqual(0.0, output);
 
   // turn the PID on
-  for (int i = 0; i < 1000; i++) {
+  for (size_t i = 0; i < 1000; i++) {
     delay(200);
     output = pPID->computeOutput(setpoint, input);
     float delta = output - input;
@@ -72,7 +72,7 @@ unittest(computeDuringCalibration) {
   assertEqual(0.0, output);
 
   // turn the PID on
-  for (int i = 0; i < 1000; i++) {
+  for (size_t i = 0; i < 1000; i++) {
     delay(200);
     output = pPID->computeOutput(setpoint, input);
     float delta = output - input;

--- a/test/SDTest.cpp
+++ b/test/SDTest.cpp
@@ -106,7 +106,7 @@ unittest(printRootDirectory) {
   state->serialPort[0].dataOut = "";
   sd->printRootDirectory();
   String output = String(state->serialPort[0].dataOut);
-  int index;
+  uint16_t index;
   index = output.indexOf("           c (     0)\r\n");
   assertNotEqual(-1, index);
   index = output.indexOf("           d/\r\n");

--- a/test/TCLibTest.cpp
+++ b/test/TCLibTest.cpp
@@ -10,8 +10,8 @@
 #include "TempProbe_TC.h"
 #include "TemperatureControl.h"
 
-const int TEMP_PIN = 47;
-const int PH_PIN = 49;
+const uint16_t TEMP_PIN = 47;
+const uint16_t PH_PIN = 49;
 
 GodmodeState *state = GODMODE();
 TankControllerLib *pTC = TankControllerLib::instance();
@@ -25,7 +25,7 @@ unittest_setup() {
   // set temperature
   tempProbe->setTemperature(20.0);
   tempProbe->setCorrection(0.0);
-  for (int i = 0; i < 100; ++i) {
+  for (size_t i = 0; i < 100; ++i) {
     delay(1000);
     tempProbe->getRunningAverage();
   }
@@ -52,7 +52,7 @@ unittest_teardown() {
 unittest(basicOperation) {
   // verify startup state, including that solonoids are off
   delay(1000);
-  assertEqual(20, (int)tempProbe->getRunningAverage());
+  assertEqual(20, (int16_t)tempProbe->getRunningAverage());
   assertEqual(7.5, pPHProbe->getPh());
   pPHControl->enablePID(false);  // Stay on continually if needed
   pTC->loop();
@@ -88,7 +88,7 @@ unittest(storeDataToSD) {
   // set date/time (so we can confirm data)
   DateTime_TC dt(2021, 4, 27, 14, 24, 50);
   dt.setAsCurrent();
-  for (int i = 0; i < 4; ++i) {
+  for (size_t i = 0; i < 4; ++i) {
     delay(500);
     pTC->loop();
   }
@@ -103,7 +103,7 @@ unittest(storeDataToSD) {
   data[file.size()] = '\0';
   COUT(data);
   String contents(data), line;
-  int i = contents.indexOf('\n');
+  int16_t i = contents.indexOf('\n');
   line = contents.substring(0, i);
   assertEqual("time,tankid,temp,temp setpoint,pH,pH setpoint,onTime,Kp,Ki,Kd", line.c_str());
   contents = contents.substring(i + 1);

--- a/test/TempProbe_TCTest.cpp
+++ b/test/TempProbe_TCTest.cpp
@@ -2,6 +2,7 @@
 #include <ArduinoUnitTests.h>
 
 #include "EEPROM_TC.h"
+#include "TC_util.h"
 #include "TempProbe_TC.h"
 
 unittest_setup() {
@@ -12,7 +13,7 @@ unittest(readFromEepromOnStartup) {
   EEPROM_TC::instance()->setCorrectedTemp(-1);
   TempProbe_TC* tempProbe = TempProbe_TC::instance();
   tempProbe->setTemperature(11.0);
-  for (int i = 0; i < 100; ++i) {
+  for (size_t i = 0; i < 100; ++i) {
     delay(1000);
     tempProbe->getRunningAverage();
   }
@@ -37,7 +38,7 @@ unittest(TempProbe_Test) {
 
   // Test getRawTemperature()
   float testTemp = tempProbe->getRawTemperature();
-  assertEqual(-242, (int)testTemp);
+  assertEqual(-242, (int16_t)testTemp);
 
   // Test readFault()
   uint8_t testFault = tempProbe->readFault();
@@ -84,7 +85,7 @@ unittest(runningAverage) {
   TempProbe_TC* tempProbe = TempProbe_TC::instance();
   tempProbe->setTemperature(10.0);
   tempProbe->setCorrection(0.0);
-  for (int i = 0; i < 100; ++i) {
+  for (size_t i = 0; i < 100; ++i) {
     delay(1000);
     tempProbe->getRunningAverage();
   }

--- a/test/TemperatureCalibrationTest.cpp
+++ b/test/TemperatureCalibrationTest.cpp
@@ -14,7 +14,7 @@ unittest(test) {
   tempProbe->setTemperature(10.0);
   tempProbe->setCorrection(0.0);
   assertEqual(0.0, EEPROM_TC::instance()->getCorrectedTemp());
-  for (int i = 0; i < 100; ++i) {
+  for (size_t i = 0; i < 100; ++i) {
     delay(1000);
     tempProbe->getRunningAverage();
   }
@@ -41,7 +41,7 @@ unittest(test) {
 
   // A new measured temperature should also be adjusted
   tempProbe->setTemperature(15.5);
-  for (int i = 0; i < 100; ++i) {
+  for (size_t i = 0; i < 100; ++i) {
     delay(1000);
     tempProbe->getRunningAverage();
   }

--- a/test/TemperatureControlTest.cpp
+++ b/test/TemperatureControlTest.cpp
@@ -15,7 +15,7 @@
  * bundle exec arduino_ci.rb --skip-examples-compilation --testfile-select=TemperatureControlTest.cpp
  */
 
-const int PIN = 47;
+const uint16_t PIN = 47;
 
 unittest_setup() {
   TankControllerLib* tc = TankControllerLib::instance();


### PR DESCRIPTION
Different compilers and platforms have different sizes for integers. It is a best practice to be explicit as to the sizes.