### PR TITLE
Don't trim last character read from stream unless it is a '\r'

### DIFF
--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -58,7 +58,7 @@ String PHProbe::getSlope() {
 void PHProbe::serialEvent1() {
   while (Serial1.available() > 0) {                 // if we see that the Atlas Scientific product has sent a character
     String string = Serial1.readStringUntil('\r');  // read the string until we see a <CR>
-    if (string.length() > 0 && string.at(string.size() - 1) == '\r') {
+    if (string.length() > 0 && string[string.length() - 1] == '\r') {
       // We should not see the CR (https://github.com/Arduino-CI/arduino_ci/pull/302)
       string.remove(string.length() - 1);
     }

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -56,9 +56,12 @@ String PHProbe::getSlope() {
  * interrupt handler for data arriving from probe
  */
 void PHProbe::serialEvent1() {
-  while (Serial1.available() > 0) {               // if we see that the Atlas Scientific product has sent a character
-    String string = Serial1.readStringUntil(13);  // read the string until we see a <CR>
-    string.remove(string.length() - 1);
+  while (Serial1.available() > 0) {                 // if we see that the Atlas Scientific product has sent a character
+    String string = Serial1.readStringUntil('\r');  // read the string until we see a <CR>
+    if (string.length() > 0 && string.at(string.size() - 1) == '\r') {
+      // We should not see the CR (https://github.com/Arduino-CI/arduino_ci/pull/302)
+      string.remove(string.length() - 1);
+    }
     if (string.length() > 0) {
       if (isdigit(string[0])) {  // if the first character in the string is a digit
         // convert the string to a floating point number so it can be evaluated by the Arduino

--- a/test/PHProbeTest.cpp
+++ b/test/PHProbeTest.cpp
@@ -25,10 +25,10 @@ unittest(serialEvent1) {
   pTC->serialEvent1();                      // fake interrupt
   assertEqual(0, pPHProbe->getPh());
   assertEqual("", pPHProbe->getSlopeResponse());
-  GODMODE()->serialPort[1].dataIn = "7.75\r?Slope,99.7,100.3,-0.89\r";  // the queue of data waiting to be read
-  pTC->serialEvent1();                                                  // fake interrupt
+  GODMODE()->serialPort[1].dataIn = "7.125\r?Slope,99.7,100.3,-0.89\r";  // the queue of data waiting to be read
+  pTC->serialEvent1();                                                   // fake interrupt
   assertEqual("?Slope,99.7,100.3,-0.89", pPHProbe->getSlopeResponse());
-  assertEqual(7.75, pPHProbe->getPh());
+  assertEqual(7.125, pPHProbe->getPh());
 }
 
 unittest(setTemperatureCompensation) {


### PR DESCRIPTION
Fix #178.