### PR TITLE
Point to TankController project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![GitHub license](https://img.shields.io/badge/license-MIT-informational.svg)](https://github.com/Open-Acidification/TankControllerLib/blob/master/LICENSE)
-[![OA Box version](https://img.shields.io/badge/TankControllerLib-v0.0.0-informational.svg)](https://github.com/Open-Acidification/TankControllerLib/releases)
-[![testing status](https://github.com/Open-Acidification/TankControllerLib/workflows/Arduino%20CI/badge.svg)](https://github.com/Open-Acidification/TankControllerLib/actions)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/Open-Acidification/TankControllerLib/blob/master/CONTRIBUTING.md)
+[![GitHub license](https://img.shields.io/badge/license-MIT-informational.svg)](https://github.com/Open-Acidification/TankController/blob/master/LICENSE)
+[![OA Box version](https://img.shields.io/badge/TankController-v0.0.0-informational.svg)](https://github.com/Open-Acidification/TankController/releases)
+[![testing status](https://github.com/Open-Acidification/TankController/workflows/Arduino%20CI/badge.svg)](https://github.com/Open-Acidification/TankController/actions)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/Open-Acidification/TankController/blob/master/CONTRIBUTING.md)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-17-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=Tank Controller
-version=0.0.1
+version=20.08.1
 author=James Foster <github@jgfoster.net>
 maintainer=James Foster <github@jgfoster.net>
 sentence=Software for the Arduino that controls pH and temperature in the Ocean Acidification project.
 paragraph=
 category=Device Control
-url=https://github.com/Open-Acidification/TankControllerLib
+url=https://github.com/Open-Acidification/TankController
 architectures=avr


### PR DESCRIPTION
We have badges that point to the (archived) TankControllerLib project (fix #237).