### PR TITLE
Update for changes to Ethernet library

### DIFF
--- a/src/Devices/Ethernet_TC.cpp
+++ b/src/Devices/Ethernet_TC.cpp
@@ -44,8 +44,10 @@ Ethernet_TC *Ethernet_TC::instance(bool reset) {
 }
 
 void Ethernet_TC::loop() {
-  // "just call it on every loop() invocation" https://www.arduino.cc/en/Reference/EthernetMaintain
-  Ethernet.maintain();
+  if (isUsingDHCP) {
+    // "just call it on every loop() invocation" https://www.arduino.cc/en/Reference/EthernetMaintain
+    Ethernet.maintain();
+  }
   numAttemptedDHCPReleases++;
 }
 

--- a/test/PushingBoxTest.cpp
+++ b/test/PushingBoxTest.cpp
@@ -71,16 +71,16 @@ unittest(SendData) {
   // set pH
   state->serialPort[1].dataIn = "7.125\r";  // the queue of data waiting to be read
   tc->serialEvent1();                       // fake interrupt
-  EthernetClient::startMockServer(pPushingBox->getServer(), 80);
-  assertEqual(0, pPushingBox->getClient()->writeBuffer().size());
-  const uint8_t response[] = "[PushingBox response]\r\n";
-  for (int i = 0; i < sizeof(response); ++i) {
-    pPushingBox->getClient()->pushToReadBuffer(response[i]);
-  }
+  EthernetClient::startMockServer(pPushingBox->getServer(), (uint32_t)0, 80,
+                                  (const uint8_t *)"[PushingBox response]\r\n");
+  EthernetClient *pClient = pPushingBox->getClient();
+  assertFalse(pClient->connected());  // not yet connected!
   state->serialPort[0].dataOut = "";
-  delay(60 * 1000);  // wait for one minute to ensure we send again
+  delay(60 * 1000);  // wait for one minute to ensure we send
   tc->loop();
-  deque<uint8_t> buffer = pPushingBox->getClient()->writeBuffer();
+  assertTrue(pClient->connected());
+  assertNotNull(pClient->writeBuffer());
+  deque<uint8_t> buffer = *(pClient->writeBuffer());
   String bufferResult;
   bool flag = false;
   for (int i = 0; i < buffer.size(); i++) {
@@ -101,10 +101,12 @@ unittest(SendData) {
       "attempting to connect to PushingBox...\r\n"
       "connected\r\n"
       "===== PushingBox response:\r\n"
-      "[PushingBox response]\r\n?"
+      "[PushingBox response]\r\n"
       "===== end of PushingBox response\r\n";
   assertEqual(expected2, state->serialPort[0].dataOut);
-  EthernetClient::stopMockServer(pPushingBox->getServer(), 80);
+  EthernetClient::stopMockServer(pPushingBox->getServer(), (uint32_t)0, 80);
+  pClient->writeBuffer()->clear();
+  pClient->stop();
 }
 
 unittest(inCalibration) {
@@ -113,11 +115,13 @@ unittest(inCalibration) {
   PHCalibrationMid *test = new PHCalibrationMid(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
-  EthernetClient::startMockServer(pPushingBox->getServer(), 80);
-  assertEqual(0, pPushingBox->getClient()->writeBuffer().size());
+  EthernetClient::startMockServer(pPushingBox->getServer(), (uint32_t)0, 80);
+  EthernetClient *pClient = pPushingBox->getClient();
+  assertNull(pClient->writeBuffer());
   delay(60 * 20 * 1000);  // wait for 20 minutes to ensure we send again
   tc->loop();
-  deque<uint8_t> buffer = pPushingBox->getClient()->writeBuffer();
+  assertNotNull(pClient->writeBuffer());
+  deque<uint8_t> buffer = *(pPushingBox->getClient()->writeBuffer());
   String bufferResult;
   for (int i = 0; i < buffer.size(); i++) {
     bufferResult += buffer[i];
@@ -128,6 +132,8 @@ unittest(inCalibration) {
       "Connection: close\r\n"
       "\r\n";
   assertEqual(expected1, bufferResult.c_str());
+  pClient->writeBuffer()->clear();
+  pClient->stop();
 }
 
 unittest(without_DHCP) {
@@ -135,12 +141,12 @@ unittest(without_DHCP) {
   assertFalse(Ethernet_TC::instance(true)->getIsUsingDHCP());
   // set tank id
   EEPROM_TC::instance()->setTankID(99);
-  EthernetClient::startMockServer(pPushingBox->getServer(), 80);
-  assertEqual(0, pPushingBox->getClient()->writeBuffer().size());
-  delay(60 * 20 * 1000);  // wait for 20 minutes to ensure we send again
+  EthernetClient::startMockServer(pPushingBox->getServer(), (uint32_t)0, 80);
+  EthernetClient *pClient = pPushingBox->getClient();
+  assertNull(pClient->writeBuffer());
+  delay(60 * 20 * 1000);  // wait for 20 minutes to ensure we still do not send
   tc->loop();
-  deque<uint8_t> buffer = pPushingBox->getClient()->writeBuffer();
-  assertEqual(0, pPushingBox->getClient()->writeBuffer().size());
+  assertNull(pClient->writeBuffer());
 }
 
 unittest_main()


### PR DESCRIPTION
* Skip `Ethernet.maintain()` if we did not get an IP address.
* Changes to PushingBox based on changes to Ethernet library.