### PR TITLE
Support basic HTTP get file request

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -166,3 +166,4 @@ wxpython
 xslx
 yaml
 yml
+yy

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -138,6 +138,7 @@ sudo
 sys
 tankid
 testfile
+Thu
 timeinfo
 Tmp
 TODO
@@ -150,6 +151,7 @@ unittest
 unixtime
 unshallow
 url
+UTF
 vfprintf
 vprintf
 vscode

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -8,11 +8,13 @@ avr
 Calib
 cassert
 cfg
+charset
 chr
 chrono
 ci
 Clib
 cmake
+concat
 config
 cout
 cpp
@@ -71,6 +73,7 @@ len
 LGPL
 libgtk
 libtc
+localhost
 localtime
 lowpoint
 LOWTHRESH
@@ -79,6 +82,7 @@ makedirs
 mday
 markdownlint
 mega
+memcmp
 memset
 microcontroler
 milli
@@ -126,6 +130,7 @@ solonoids
 src
 strcpy
 strlen
+strncmp
 strnlen
 strncpy
 substr

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -93,8 +93,6 @@ bool EthernetServer_TC::file() {
       client.flush();
       timeInFlush += millis() - startTime;
       ++flushCount;
-      // serial(F("totalBytes = %lu; flush took %lu millis"), totalBytes, after - before);
-      // delay(10);
     }
   }
   file.close();

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -1,6 +1,11 @@
 #include "Devices/EthernetServer_TC.h"
 
+#include <avr/wdt.h>
+
+#include "DateTime_TC.h"
+#include "SD_TC.h"
 #include "Serial_TC.h"
+#include "TankControllerLib.h"
 
 //  class variables
 EthernetServer_TC* EthernetServer_TC::_instance = nullptr;
@@ -22,26 +27,153 @@ EthernetServer_TC* EthernetServer_TC::instance() {
  */
 EthernetServer_TC::EthernetServer_TC(uint16_t port) : EthernetServer(port) {
   begin();
-  serial("Ethernet Server is listening on port 80 of ??????");
-  //   TODO: Need Mock board for .localIP to work
-  //   serial(Ethernet.localIP());
+  serial("Ethernet Server is listening on port %d", port);
 }
 
-/**
- * Look for request from external client and handle it.
- * This (incomplete) code copied from HandleRequest()
- */
-void EthernetServer_TC::handleRequest() {
-  // listen for incoming clients
-  EthernetClient rpc_client = available();  // Raspberry Pi Client
-  if (rpc_client) {
-    // TODO: NEED TO IMPLEMENT
-    // HandleRequest(rpc_client);
-
-    // give the web browser time to receive the data
-    // delay(ONE_SECOND_DELAY_IN_MILLIS);
-    // close the connection:
-    rpc_client.stop();
-    serial("rpc_client disconnected");
+void EthernetServer_TC::echo() {
+  serial("echo() - \"%s\"", buffer + 19);
+  int i = 19;
+  while (buffer[i] != ' ' && buffer[i] != '\0') {
+    ++i;
   }
+  serial("echo() found space or null at %d", i);
+  if (memcmp(buffer + i - 3, "%22", 3)) {
+    serial("bad");
+  } else {
+    buffer[i - 3] = '\0';
+    serial("echo \"%s\"", buffer + 19);
+    sendHeadersWithSize(strlen(buffer + 19));
+    client.write(buffer + 19);
+    client.stop();
+    state = NOT_CONNECTED;
+  }
+}
+
+bool EthernetServer_TC::file() {
+  int i = 4;
+  while (buffer[i] != ' ') {
+    ++i;
+  }
+  buffer[i] = '\0';
+  if (!SD_TC::instance()->exists(buffer + 4)) {
+    serial("file - \"%s\" not found!", buffer + 4);
+    return false;
+  }
+  File file = SD_TC::instance()->open(buffer + 4);
+  uint32_t size = file.size();
+  serial("file \"%s\" has a size of %lu", buffer + 4, size);
+  sendHeadersWithSize(size);
+  uint32_t total = 0;
+  wdt_disable();
+  uint32_t start = millis();
+  uint32_t flushCount = 0;
+  uint32_t flushTime = 0;
+  while (file.available32()) {
+    int readSize = file.read(buffer, sizeof(buffer));
+    int writeSize = client.write(buffer, readSize);
+    if (writeSize != readSize) {
+      serial("total = %lu; read = %d; write = %d", total, readSize, writeSize);
+      break;
+    }
+    total += writeSize;
+    if (total % 8196 == 0) {
+      uint32_t before = millis();
+      client.flush();
+      uint32_t after = millis();
+      ++flushCount;
+      flushTime += after - before;
+      // serial("total = %lu; flush took %lu millis", total, after - before);
+      // delay(10);
+    }
+  }
+  uint32_t end = millis();
+  file.close();
+  client.stop();
+  state = NOT_CONNECTED;
+  serial("write = %lu; freeMemory = %lu", total, (unsigned long int)TankControllerLib::instance()->freeMemory());
+  serial("time = %lu; average flush time = %lu", end - start, (uint32_t)flushTime / flushCount);
+  wdt_enable(WDTO_8S);
+  return true;
+}
+
+void EthernetServer_TC::get() {
+  if (memcmp(buffer + 4, "/echo?value=%22", 15) == 0) {
+    echo();
+  } else if (!file()) {
+    // TODO: send an error response
+    serial("get \"%s\" not recognized!", buffer + 4);
+    client.stop();
+    state = NOT_CONNECTED;
+  }
+}
+
+void EthernetServer_TC::loop() {
+  if (client || (client = accept())) {  // if we have a connection
+    if (state == NOT_CONNECTED) {
+      state = READ_REQUEST;
+      bufferContentsSize = 0;
+      connectedAt = millis();  // record start time (so we can do timeout)
+    }
+    // read request
+    int next;
+    while (state == READ_REQUEST && bufferContentsSize < sizeof(buffer) && (next = client.read()) != -1) {
+      buffer[bufferContentsSize++] = (char)(next & 0xFF);
+      if (bufferContentsSize > 1 && buffer[bufferContentsSize - 2] == '\r' && buffer[bufferContentsSize - 1] == '\n') {
+        buffer[bufferContentsSize - 2] = '\0';
+        state = HAS_REQUEST;
+        if (memcmp(buffer, "GET ", 4) == 0) {
+          state = GET_REQUEST;
+          break;
+        }
+        break;
+      }
+    }
+    switch (state) {
+      case GET_REQUEST:
+        get();
+        break;
+      default:
+        break;
+    }
+  } else if (state != NOT_CONNECTED) {  // existing connection has been closed
+    state = NOT_CONNECTED;
+    bufferContentsSize = 0;
+    client.stop();
+    connectedAt = 0;
+  } else {
+    // no client and not recently connected
+  }
+}
+
+void EthernetServer_TC::sendHeadersWithSize(uint32_t size) {
+  const char response[] =
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: text/plain;charset=UTF-8\r\n"
+      "Content-Encoding: identity\r\n"
+      "Content-Language: en-US\r\n";
+  client.write(response);
+  char buffer[40];
+  snprintf(buffer, sizeof(buffer), "Content-Length: %lu\r\n", (unsigned long)size);
+  client.write(buffer);
+
+  // TODO: add "Date:"" header
+  const char* weekdays[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+  const char* months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+  DateTime_TC now = DateTime_TC::now();
+  // int weekday = weekday(now.getYear(), now.getMonth(), now.getDay());
+  // snprintf(buffer, sizeof(buffer), "Date: %s, %02d %s %04d %02d:%02d:%02d GMT\r\n", );
+
+  // blank line indicates end of headers
+  client.write("\r\n");
+}
+
+int EthernetServer_TC::weekday(int year, int month, int day) {
+  // Calculate day of week in proleptic Gregorian calendar. Sunday == 0.
+  int adjustment, mm, yy;
+  if (year < 2000)
+    year += 2000;
+  adjustment = (14 - month) / 12;
+  mm = month + 12 * adjustment - 2;
+  yy = year - adjustment;
+  return (day + (13 * mm - 1) / 5 + yy + yy / 4 - yy / 100 + yy / 400) % 7;
 }

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -31,17 +31,17 @@ EthernetServer_TC::EthernetServer_TC(uint16_t port) : EthernetServer(port) {
 }
 
 void EthernetServer_TC::echo() {
-  serial("echo() - \"%s\"", buffer + 19);
+  serial(F("echo() - \"%s\""), buffer + 19);
   int i = 19;
   while (buffer[i] != ' ' && buffer[i] != '\0') {
     ++i;
   }
-  serial("echo() found space or null at %d", i);
+  serial(F("echo() found space or null at %d"), i);
   if (memcmp(buffer + i - 3, "%22", 3)) {
-    serial("bad");
+    serial(F("bad"));
   } else {
     buffer[i - 3] = '\0';
-    serial("echo \"%s\"", buffer + 19);
+    serial(F("echo \"%s\""), buffer + 19);
     sendHeadersWithSize(strlen(buffer + 19));
     client.write(buffer + 19);
     client.stop();
@@ -56,12 +56,12 @@ bool EthernetServer_TC::file() {
   }
   buffer[i] = '\0';
   if (!SD_TC::instance()->exists(buffer + 4)) {
-    serial("file - \"%s\" not found!", buffer + 4);
+    serial(F("file - \"%s\" not found!"), buffer + 4);
     return false;
   }
   File file = SD_TC::instance()->open(buffer + 4);
   uint32_t size = file.size();
-  serial("file \"%s\" has a size of %lu", buffer + 4, size);
+  serial(F("file \"%s\" has a size of %lu"), buffer + 4, size);
   sendHeadersWithSize(size);
   uint32_t total = 0;
   wdt_disable();
@@ -72,7 +72,7 @@ bool EthernetServer_TC::file() {
     int readSize = file.read(buffer, sizeof(buffer));
     int writeSize = client.write(buffer, readSize);
     if (writeSize != readSize) {
-      serial("total = %lu; read = %d; write = %d", total, readSize, writeSize);
+      serial(F("total = %lu; read = %d; write = %d"), total, readSize, writeSize);
       break;
     }
     total += writeSize;
@@ -82,7 +82,7 @@ bool EthernetServer_TC::file() {
       uint32_t after = millis();
       ++flushCount;
       flushTime += after - before;
-      // serial("total = %lu; flush took %lu millis", total, after - before);
+      // serial(F("total = %lu; flush took %lu millis"), total, after - before);
       // delay(10);
     }
   }
@@ -90,8 +90,8 @@ bool EthernetServer_TC::file() {
   file.close();
   client.stop();
   state = NOT_CONNECTED;
-  serial("write = %lu; freeMemory = %i", total, TankControllerLib::instance()->freeMemory());
-  serial("time = %lu; average flush time = %lu", end - start, (uint32_t)flushTime / flushCount);
+  serial(F("write = %lu; freeMemory = %i"), total, TankControllerLib::instance()->freeMemory());
+  serial(F("time = %lu; average flush time = %lu"), end - start, (uint32_t)flushTime / flushCount);
   wdt_enable(WDTO_8S);
   return true;
 }
@@ -101,7 +101,7 @@ void EthernetServer_TC::get() {
     echo();
   } else if (!file()) {
     // TODO: send an error response
-    serial("get \"%s\" not recognized!", buffer + 4);
+    serial(F("get \"%s\" not recognized!"), buffer + 4);
     client.stop();
     state = NOT_CONNECTED;
   }

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -42,7 +42,7 @@ void EthernetServer_TC::echo() {
   } else {
     buffer[i - 3] = '\0';
     serial(F("echo \"%s\""), buffer + 19);
-    sendHeadersWithSize(strlen(buffer + 19));
+    sendHeadersWithSize(strnlen(buffer + 19, sizeof(buffer) - 20));
     client.write(buffer + 19);
     client.stop();
     state = NOT_CONNECTED;
@@ -72,13 +72,12 @@ bool EthernetServer_TC::file() {
   uint32_t timeInRead = 0;
   uint32_t timeInWrite = 0;
   uint32_t timeInFlush = 0;
-  uint32_t startTime = 0;
 
   wdt_disable();
   uint32_t flushCount = 0;
   while (file.available32()) {
-    startTime = millis();
-    int readSize = file.read(buffer, sizeof(buffer));
+    uint32_t startTime = millis();
+    int readSize = file.read(buffer, sizeof(buffer));  // Flawfinder: ignore
     timeInRead += millis() - startTime;
     startTime = millis();
     int writeSize = client.write(buffer, readSize);
@@ -124,7 +123,8 @@ void EthernetServer_TC::loop() {
     }
     // read request
     int next;
-    while (state == READ_REQUEST && bufferContentsSize < sizeof(buffer) && (next = client.read()) != -1) {
+    while (state == READ_REQUEST && bufferContentsSize < sizeof(buffer) &&
+           (next = client.read()) != -1) {  // Flawfinder: ignore
       buffer[bufferContentsSize++] = (char)(next & 0xFF);
       if (bufferContentsSize > 1 && buffer[bufferContentsSize - 2] == '\r' && buffer[bufferContentsSize - 1] == '\n') {
         buffer[bufferContentsSize - 2] = '\0';
@@ -166,10 +166,10 @@ void EthernetServer_TC::sendHeadersWithSize(uint32_t size) {
   client.write(buffer);
 
   // TODO: add "Date: " header
-  const __FlashStringHelper* weekdays[] = {F("Sun"), F("Mon"), F("Tue"), F("Wed"), F("Thu"), F("Fri"), F("Sat")};
-  const __FlashStringHelper* months[] = {F("Jan"), F("Feb"), F("Mar"), F("Apr"), F("May"), F("Jun"),
-                                         F("Jul"), F("Aug"), F("Sep"), F("Oct"), F("Nov"), F("Dec")};
-  DateTime_TC now = DateTime_TC::now();
+  // const __FlashStringHelper* weekdays[] = {F("Sun"), F("Mon"), F("Tue"), F("Wed"), F("Thu"), F("Fri"), F("Sat")};
+  // const __FlashStringHelper* months[] = {F("Jan"), F("Feb"), F("Mar"), F("Apr"), F("May"), F("Jun"),
+  //                                        F("Jul"), F("Aug"), F("Sep"), F("Oct"), F("Nov"), F("Dec")};
+  // DateTime_TC now = DateTime_TC::now();
   // int weekday = weekday(now.getYear(), now.getMonth(), now.getDay());
   // snprintf_P(buffer, sizeof(buffer), F("Date: %s, %02d %s %04d %02d:%02d:%02d GMT\r\n"), );
 

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -90,7 +90,7 @@ bool EthernetServer_TC::file() {
   file.close();
   client.stop();
   state = NOT_CONNECTED;
-  serial("write = %lu; freeMemory = %lu", total, (unsigned long int)TankControllerLib::instance()->freeMemory());
+  serial("write = %lu; freeMemory = %i", total, TankControllerLib::instance()->freeMemory());
   serial("time = %lu; average flush time = %lu", end - start, (uint32_t)flushTime / flushCount);
   wdt_enable(WDTO_8S);
   return true;

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -31,7 +31,7 @@ private:
   // instance variables
   EthernetClient client;
   serverState_t state = NOT_CONNECTED;
-  char buffer[128];
+  char buffer[1024];
   int bufferContentsSize = 0;
   unsigned long connectedAt = 0;
 

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -7,7 +7,7 @@
 #include <Ethernet.h>
 #endif
 
-enum serverState_t { NOT_CONNECTED, READ_REQUEST, GET_REQUEST, HAS_REQUEST, HAS_HEADERS };
+enum serverState_t { NOT_CONNECTED, READ_REQUEST, GET_REQUEST, HAS_REQUEST };
 
 /**
  * EthernetServer_TC provides wrapper for web server for TankController

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -7,6 +7,8 @@
 #include <Ethernet.h>
 #endif
 
+enum serverState_t { NOT_CONNECTED, READ_REQUEST, GET_REQUEST, HAS_REQUEST, HAS_HEADERS };
+
 /**
  * EthernetServer_TC provides wrapper for web server for TankController
  *
@@ -20,12 +22,26 @@ public:
   const char* className() const {
     return "EthernetServer_TC";
   }
-  void handleRequest();
+  void loop();
 
 private:
   // class variables
   static EthernetServer_TC* _instance;
 
-  // instance methods
+  // instance variables
+  EthernetClient client;
+  serverState_t state = NOT_CONNECTED;
+  char buffer[128];
+  int bufferContentsSize = 0;
+  unsigned long connectedAt = 0;
+
+  // instance methods: constructor
   EthernetServer_TC(uint16_t port);
+  // instance methods: utility
+  void sendHeadersWithSize(uint32_t size);
+  int weekday(int year, int month, int day);
+  // instance methods: HTTP
+  void echo();
+  bool file();
+  void get();
 };

--- a/src/Devices/PushingBox.cpp
+++ b/src/Devices/PushingBox.cpp
@@ -33,13 +33,13 @@ void PushingBox::loop() {
   // is it time to send ?
   unsigned long now = millis();
   if (now >= nextSendTime) {
-    // serial("PushingBox::loop() - 1");
+    // serial(F("PushingBox::loop() - 1"));
     if (false && strncmp(DevID, "PushingBoxIdentifier", 20) == 0) {
-      serial("PushingBox identifier not defined in TankController.ino!");
+      serial(F("PushingBox identifier not defined in TankController.ino!"));
     } else {
-      // serial("PushingBox::loop() - 2; free memory = %i", TankControllerLib::instance()->freeMemory());
+      // serial(F("PushingBox::loop() - 2; free memory = %i", TankControllerLib::instance()->freeMemory());
       sendData();
-      // serial("PushingBox::loop() - 3");
+      // serial(F("PushingBox::loop() - 3")));
     }
     unsigned long minutes = EEPROM_TC::instance()->getGoogleSheetInterval();
     if (minutes == 0xffff) {
@@ -67,14 +67,14 @@ void PushingBox::loop() {
 }
 
 void PushingBox::sendData() {
-  // serial("PushingBox::sendData() - 1; free memory = %i", TankControllerLib::instance()->freeMemory());
+  // serial(F("PushingBox::sendData() - 1; free memory = %i"), TankControllerLib::instance()->freeMemory());
   int tankID = EEPROM_TC::instance()->getTankID();
   if (!tankID) {
     serial(F("Set Tank ID in order to send data to PushingBox"));
     return;
   }
   char buffer[200];
-  // serial("PushingBox::sendData() - 2; free memory = %i", TankControllerLib::instance()->freeMemory());
+  // serial(F("PushingBox::sendData() - 2; free memory = %i"), TankControllerLib::instance()->freeMemory());
   if (TankControllerLib::instance()->isInCalibration()) {
     char format[] PROGMEM =
         "GET /pushingbox?devid=%s&tankid=%i&tempData=C&pHdata=C HTTP/1.1\r\n"

--- a/src/Devices/PushingBox.cpp
+++ b/src/Devices/PushingBox.cpp
@@ -76,14 +76,14 @@ void PushingBox::sendData() {
   char buffer[200];
   // serial(F("PushingBox::sendData() - 2; free memory = %i"), TankControllerLib::instance()->freeMemory());
   if (TankControllerLib::instance()->isInCalibration()) {
-    char format[] PROGMEM =
+    static const char format[] PROGMEM =
         "GET /pushingbox?devid=%s&tankid=%i&tempData=C&pHdata=C HTTP/1.1\r\n"
         "Host: api.pushingbox.com\r\n"
         "Connection: close\r\n"
         "\r\n";
     snprintf_P(buffer, sizeof(buffer), (PGM_P)format, DevID, tankID);
   } else {
-    char format[] PROGMEM =
+    static const char format[] PROGMEM =
         "GET /pushingbox?devid=%s&tankid=%i&tempData=%.2f&pHdata=%.3f HTTP/1.1\r\n"
         "Host: api.pushingbox.com\r\n"
         "Connection: close\r\n"

--- a/src/Devices/PushingBox.cpp
+++ b/src/Devices/PushingBox.cpp
@@ -33,12 +33,13 @@ void PushingBox::loop() {
   // is it time to send ?
   unsigned long now = millis();
   if (now >= nextSendTime) {
+    // serial("PushingBox::loop() - 1");
     if (false && strncmp(DevID, "PushingBoxIdentifier", 20) == 0) {
       serial("PushingBox identifier not defined in TankController.ino!");
-      nextSendTime = 0xffffffff;
-      return;
     } else {
+      // serial("PushingBox::loop() - 2; free memory = %i", TankControllerLib::instance()->freeMemory());
       sendData();
+      // serial("PushingBox::loop() - 3");
     }
     unsigned long minutes = EEPROM_TC::instance()->getGoogleSheetInterval();
     if (minutes == 0xffff) {
@@ -66,12 +67,14 @@ void PushingBox::loop() {
 }
 
 void PushingBox::sendData() {
+  // serial("PushingBox::sendData() - 1; free memory = %i", TankControllerLib::instance()->freeMemory());
   int tankID = EEPROM_TC::instance()->getTankID();
   if (!tankID) {
     serial("Set Tank ID in order to send data to PushingBox");
     return;
   }
   char buffer[200];
+  // serial("PushingBox::sendData() - 2; free memory = %i", TankControllerLib::instance()->freeMemory());
   if (TankControllerLib::instance()->isInCalibration()) {
     char format[] =
         "GET /pushingbox?devid=%s&tankid=%i&tempData=C&pHdata=C HTTP/1.1\r\n"
@@ -80,6 +83,7 @@ void PushingBox::sendData() {
         "\r\n";
     snprintf(buffer, sizeof(buffer), format, DevID, tankID);
   } else {
+    // serial("PushingBox::sendData() - 3; free memory = %i", TankControllerLib::instance()->freeMemory());
     char format[] =
         "GET /pushingbox?devid=%s&tankid=%i&tempData=%.2f&pHdata=%.3f HTTP/1.1\r\n"
         "Host: api.pushingbox.com\r\n"
@@ -97,6 +101,7 @@ void PushingBox::sendData() {
       break;
     }
   }
+  // serial("PushingBox::sendData() - 4; free memory = %i", TankControllerLib::instance()->freeMemory());
   serial(buffer);
   buffer[i] = '\r';
   serial("attempting to connect to PushingBox...");

--- a/src/Devices/PushingBox.cpp
+++ b/src/Devices/PushingBox.cpp
@@ -33,7 +33,13 @@ void PushingBox::loop() {
   // is it time to send ?
   unsigned long now = millis();
   if (now >= nextSendTime) {
-    sendData();
+    if (false && strncmp(DevID, "PushingBoxIdentifier", 20) == 0) {
+      serial("PushingBox identifier not defined in TankController.ino!");
+      nextSendTime = 0xffffffff;
+      return;
+    } else {
+      sendData();
+    }
     unsigned long minutes = EEPROM_TC::instance()->getGoogleSheetInterval();
     if (minutes == 0xffff) {
       minutes = 20;

--- a/src/Devices/PushingBox.cpp
+++ b/src/Devices/PushingBox.cpp
@@ -33,14 +33,7 @@ void PushingBox::loop() {
   // is it time to send ?
   unsigned long now = millis();
   if (now >= nextSendTime) {
-    // serial(F("PushingBox::loop() - 1"));
-    if (false && strncmp_P(DevID, (PGM_P)F("PushingBoxIdentifier"), 20) == 0) {
-      serial(F("PushingBox identifier not defined in TankController.ino!"));
-    } else {
-      // serial(F("PushingBox::loop() - 2; free memory = %i", TankControllerLib::instance()->freeMemory());
-      sendData();
-      // serial(F("PushingBox::loop() - 3")));
-    }
+    sendData();
     unsigned long minutes = EEPROM_TC::instance()->getGoogleSheetInterval();
     if (minutes == 0xffff) {
       minutes = 20;
@@ -67,14 +60,12 @@ void PushingBox::loop() {
 }
 
 void PushingBox::sendData() {
-  // serial(F("PushingBox::sendData() - 1; free memory = %i"), TankControllerLib::instance()->freeMemory());
   int tankID = EEPROM_TC::instance()->getTankID();
   if (!tankID) {
     serial(F("Set Tank ID in order to send data to PushingBox"));
     return;
   }
   char buffer[200];
-  // serial(F("PushingBox::sendData() - 2; free memory = %i"), TankControllerLib::instance()->freeMemory());
   if (TankControllerLib::instance()->isInCalibration()) {
     static const char format[] PROGMEM =
         "GET /pushingbox?devid=%s&tankid=%i&tempData=C&pHdata=C HTTP/1.1\r\n"

--- a/src/Devices/PushingBox.cpp
+++ b/src/Devices/PushingBox.cpp
@@ -34,7 +34,7 @@ void PushingBox::loop() {
   unsigned long now = millis();
   if (now >= nextSendTime) {
     // serial(F("PushingBox::loop() - 1"));
-    if (false && strncmp(DevID, "PushingBoxIdentifier", 20) == 0) {
+    if (false && strncmp_P(DevID, (PGM_P)F("PushingBoxIdentifier"), 20) == 0) {
       serial(F("PushingBox identifier not defined in TankController.ino!"));
     } else {
       // serial(F("PushingBox::loop() - 2; free memory = %i", TankControllerLib::instance()->freeMemory());

--- a/src/Devices/PushingBox.h
+++ b/src/Devices/PushingBox.h
@@ -26,7 +26,7 @@ private:
   EthernetClient client;
   const char *DevID = nullptr;  // DeviceID assigned by PushingBox and passed-in from TankController.ino
   // wait a bit for first reading (https://github.com/Open-Acidification/TankController/issues/179)
-  unsigned long nextSendTime = 70000;
+  uint32_t nextSendTime = 70000;
   const char *server = "api.pushingbox.com";
 
   // instance method

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -91,11 +91,8 @@ File SD_TC::open(const char* path, oflag_t oflag) {
   return sd.open(path, oflag);
 }
 
-/**
- * print the root directory and all subdirectories
- */
 void SD_TC::printRootDirectory() {
-  // serial("SD_TC::printRootDirectory()");
+  sd.ls(LS_DATE | LS_SIZE | LS_R);
 }
 
 String SD_TC::todaysDataFileName() {

--- a/src/Devices/Serial_TC.cpp
+++ b/src/Devices/Serial_TC.cpp
@@ -50,8 +50,7 @@ void Serial_TC::vprintf(const char *format, va_list args) {
   // need to avoid recursion since SD_TC could call serial()
   if (!printIsActive) {
     printIsActive = true;
-    // this seems to cause problems on the actual hardware
-    // SD_TC::instance()->appendToLog(buffer);
+    SD_TC::instance()->appendToLog(buffer);
     printIsActive = false;
   }
 #ifdef MOCK_PINS_COUNT

--- a/src/TankControllerLib.cpp
+++ b/src/TankControllerLib.cpp
@@ -88,7 +88,7 @@ void TankControllerLib::blink() {
 }
 
 // https://github.com/maniacbug/MemoryFree/blob/master/MemoryFree.cpp
-size_t TankControllerLib::freeMemory() {
+int TankControllerLib::freeMemory() {
 #ifdef MOCK_PINS_COUNT
   int *__brkval = 0;
   int __bss_end = 0;
@@ -101,7 +101,7 @@ size_t TankControllerLib::freeMemory() {
   if ((size_t)__brkval == 0) {
     return ((size_t)&topOfStack) - ((size_t)&__bss_end);
   }
-  return ((size_t)&topOfStack) - ((size_t)__brkval);
+  return (int)((size_t)&topOfStack) - ((size_t)__brkval);
 }
 
 /**

--- a/src/TankControllerLib.cpp
+++ b/src/TankControllerLib.cpp
@@ -43,7 +43,7 @@ TankControllerLib *TankControllerLib::instance(const char *pushingBoxID) {
  * Constructor
  */
 TankControllerLib::TankControllerLib() {
-  serial("TankControllerLib::TankControllerLib() - version %s", TANK_CONTROLLER_VERSION);
+  serial("\r\n#################\r\nTankControllerLib::TankControllerLib() - version %s", TANK_CONTROLLER_VERSION);
   assert(!_instance);
   // ensure we have instances
   SD_TC::instance();

--- a/src/TankControllerLib.cpp
+++ b/src/TankControllerLib.cpp
@@ -44,7 +44,7 @@ TankControllerLib *TankControllerLib::instance(const char *pushingBoxID) {
  * Constructor
  */
 TankControllerLib::TankControllerLib() {
-  serial("\r\n#################\r\nTankControllerLib::TankControllerLib() - version %s", TANK_CONTROLLER_VERSION);
+  serial(F("\r\n#################\r\nTankControllerLib::TankControllerLib() - version %s"), TANK_CONTROLLER_VERSION);
   assert(!_instance);
   // ensure we have instances
   SD_TC::instance();

--- a/src/TankControllerLib.cpp
+++ b/src/TankControllerLib.cpp
@@ -260,7 +260,7 @@ void TankControllerLib::writeDataToSD() {
   }
   static const char header[] = "time,tankid,temp,temp setpoint,pH,pH setpoint,onTime,Kp,Ki,Kd";
   static const char format[] PROGMEM =
-      "%02i/%02i/%4i %02i:%02i:%02i, %3i, %s, %4.2f, %s, %5.3f, %4i, %8.1f, %8.1f, %8.1f";
+      "%02i/%02i/%4i %02i:%02i:%02i, %3i, %s, %4.2f, %s, %5.3f, %4lu, %8.1f, %8.1f, %8.1f";
   char buffer[128];
   DateTime_TC dtNow = DateTime_TC::now();
   PID_TC *pPID = PID_TC::instance();
@@ -268,7 +268,7 @@ void TankControllerLib::writeDataToSD() {
   snprintf_P(buffer, sizeof(buffer), (PGM_P)format, (uint16_t)dtNow.month(), (uint16_t)dtNow.day(),
              (uint16_t)dtNow.year(), (uint16_t)dtNow.hour(), (uint16_t)dtNow.minute(), (uint16_t)dtNow.second(),
              (uint16_t)tankId, currentTemp, (float)TemperatureControl::instance()->getTargetTemperature(), currentPh,
-             (float)PHControl::instance()->getTargetPh(), (uint16_t)(millis() / 1000), (float)pPID->getKp(),
+             (float)PHControl::instance()->getTargetPh(), (unsigned long)(millis() / 1000), (float)pPID->getKp(),
              (float)pPID->getKi(), (float)pPID->getKd());
   SD_TC::instance()->appendData(header, buffer);
   nextWriteTime = msNow / 1000 * 1000 + 1000;  // round up to next second

--- a/src/TankControllerLib.cpp
+++ b/src/TankControllerLib.cpp
@@ -4,6 +4,7 @@
 
 #include "Devices/DateTime_TC.h"
 #include "Devices/EEPROM_TC.h"
+#include "Devices/EthernetServer_TC.h"
 #include "Devices/Ethernet_TC.h"
 #include "Devices/Keypad_TC.h"
 #include "Devices/LiquidCrystal_TC.h"
@@ -148,13 +149,14 @@ void TankControllerLib::handleUI() {
  */
 void TankControllerLib::loop() {
   wdt_reset();
-  blink();                          // blink the on-board LED to show that we are running
-  handleUI();                       // look at keypad, update LCD
-  updateControls();                 // turn CO2 and temperature controls on or off
-  writeDataToSD();                  // record current state to data log
-  writeDataToSerial();              // record current pH and temperature to serial
-  PushingBox::instance()->loop();   // write data to Google Sheets
-  Ethernet_TC::instance()->loop();  // renew DHCP lease
+  blink();                                // blink the on-board LED to show that we are running
+  handleUI();                             // look at keypad, update LCD
+  updateControls();                       // turn CO2 and temperature controls on or off
+  writeDataToSD();                        // record current state to data log
+  writeDataToSerial();                    // record current pH and temperature to serial
+  PushingBox::instance()->loop();         // write data to Google Sheets
+  Ethernet_TC::instance()->loop();        // renew DHCP lease
+  EthernetServer_TC::instance()->loop();  // handle any HTTP requests
 }
 
 /**

--- a/src/TankControllerLib.h
+++ b/src/TankControllerLib.h
@@ -16,7 +16,7 @@ public:
 
   // instance methods
   bool isInCalibration();
-  size_t freeMemory();
+  int freeMemory();
   void loop();
   void serialEvent();
   void serialEvent1();

--- a/src/UIState/SeeFreeMemory.cpp
+++ b/src/UIState/SeeFreeMemory.cpp
@@ -6,6 +6,6 @@
 void SeeFreeMemory::start() {
   LiquidCrystal_TC::instance()->writeLine(prompt(), 0);
   char buffer[17];
-  snprintf(buffer, sizeof(buffer), "%i bytes", (int)TankControllerLib::instance()->freeMemory());
+  snprintf(buffer, sizeof(buffer), "%i bytes", TankControllerLib::instance()->freeMemory());
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
 }

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -8,10 +8,44 @@
  * Trivial test to confirm that EthernetServer_TC compiles,
  * is of proper class, and has proper port
  */
-unittest(test) {
+unittest(basic) {
   EthernetServer_TC* server = EthernetServer_TC::instance();
+  EthernetClient_CI client;
   assertEqual("EthernetServer_TC", server->className());
   assertEqual(80, server->getPort());
+  server->setHasClientCalling(true);
+  delay(1);        // so that start time is not zero!
+  server->loop();  // accept connection
+  client = server->getClient();
+  assertTrue(client);
+  assertEqual(0, client.writeBuffer()->size());
+  const char request[] =
+      "GET /echo?value=%22foo%22 HTTP/1.1\r\n"
+      "Host: localhost:80\r\n"
+      "Accept: text/plain;charset=UTF-8\r\n"
+      "Accept-Encoding: identity\r\n"
+      "Accept-Language: en-US\r\n"
+      "\r\n";
+  client.pushToReadBuffer(request);
+  server->loop();  // generate response
+  deque<uint8_t>* pBuffer = client.writeBuffer();
+  assertTrue(pBuffer->size() > 100);
+  String response;
+  while (!pBuffer->empty()) {
+    response.concat(pBuffer->front());
+    pBuffer->pop_front();
+  }
+  const char expectedResponse[] =
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: text/plain;charset=UTF-8\r\n"
+      "Content-Encoding: identity\r\n"
+      "Content-Language: en-US\r\n"
+      "Content-Length: 3\r\n"
+      "\r\n"
+      "foo";
+  assertEqual(expectedResponse, response);
+  client.stop();
+  server->loop();  // notify server that client stopped
 }
 
 unittest_main()


### PR DESCRIPTION
This supports `/echo?key="value"` requests and `/path` requests. Large files take a long time to transfer. Following are some measurements of time with different buffer sizes:

```
Buffer size: 128
file "/20210827.csv" has a size of 5713467
write = 5713467; freeMemory = 4640
timeInRead = 27661; timeInWrite = 79832; timeInFlush = 43

Buffer size: 2048
file "/20210827.csv" has a size of 5858009
write = 5858009; freeMemory = 2720
timeInRead = 11681; timeInWrite = 74739; timeInFlush = 3

Buffer size: 1024
file "/20210827.csv" has a size of 5878029
write = 5878029; freeMemory = 3744
timeInRead = 15108; timeInWrite = 72649; timeInFlush = 3
```

The entire process is blocking so there is a risk of leaving the bubbler on for minutes. Thus, the reading files feature should be considered a basic alternative to taking the device apart to read files.