### PR TITLE
Include size report with each PR

### DIFF
--- a/.github/workflows/Arduino-CI.yaml
+++ b/.github/workflows/Arduino-CI.yaml
@@ -19,3 +19,5 @@ jobs:
           g++ -v
           scripts/install_libraries.sh
           scripts/testAndBuild.sh
+      - name: Ensure no Git changes
+        run: (exit `git status -s -uno | wc -l`)

--- a/.github/workflows/Arduino-CI.yaml
+++ b/.github/workflows/Arduino-CI.yaml
@@ -20,4 +20,6 @@ jobs:
           scripts/install_libraries.sh
           scripts/testAndBuild.sh
       - name: Ensure no Git changes
-        run: (exit `git status -s -uno | wc -l`)
+        run: |
+          git status -s -uno
+          (exit `git status -s -uno | wc -l`)

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ arduino-cli.yaml
 *.elf
 *.eep
 libraries
+output.txt
 
 # Arduino-CI Files
 Gemfile.lock

--- a/scripts/testAndBuild.sh
+++ b/scripts/testAndBuild.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 bundle install --path vendor/bundle
-bundle exec arduino_ci.rb --min-free-space=5800
+bundle exec arduino_ci.rb --min-free-space=5800 | tee output.txt
+tail -n 4 output.txt | head -n 2 > size.txt

--- a/size.txt
+++ b/size.txt
@@ -1,2 +1,2 @@
 Sketch uses 69980 bytes (27%) of program storage space. Maximum is 253952 bytes.
-Global variables use 2186 bytes (26%) of dynamic memory, leaving 6000 bytes for local variables. Maximum is 8192 bytes.
+Global variables use 2186 bytes (26%) of dynamic memory, leaving 6006 bytes for local variables. Maximum is 8192 bytes.

--- a/size.txt
+++ b/size.txt
@@ -1,0 +1,2 @@
+Sketch uses 69980 bytes (27%) of program storage space. Maximum is 253952 bytes.
+Global variables use 2186 bytes (26%) of dynamic memory, leaving 6000 bytes for local variables. Maximum is 8192 bytes.


### PR DESCRIPTION
The arduino_ci test updates `size.txt` when it builds the sketch. Thus each commit will include the current values (if the tests are run!). You can see the new size by viewing the modified files. To ensure that the tests are run before a PR, part of the GitHub action is to update the file and see if it changes. See [here](https://github.com/jgfoster/TankController/runs/3518130868?check_suite_focus=true) for a sample failure.

Fix #139.