### PR TITLE
Change Arduino Library Lint to recognize we are in the public library listing

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,3 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/arduino-lint-action@v1
+        with:
+          library-manager: update


### PR DESCRIPTION
This should avoid the error we get now that the name is a duplicate. See #255.