### PR TITLE
Switch from jgfoster to Arduino-CI for testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem 'arduino_ci', git: 'https://github.com/jgfoster/arduino_ci', branch: 'main'
+gem 'arduino_ci', git: 'https://github.com/Arduino-CI/arduino_ci', branch: 'master'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,6 @@ sudo apt install -y \
 sudo gem install bundler
 git clone https://github.com/Open-Acidification/TankController.git
 cd TankController
-bundle config --local path vendor/bundle
+bundle config set --local path 'vendor/bundle'
 bundle install
 scripts/install_libraries.sh

--- a/scripts/install_libraries.sh
+++ b/scripts/install_libraries.sh
@@ -10,7 +10,7 @@ export SHALLOW_MASTER='--depth 1 --branch master --single-branch '
 # git fetch --unshallow
 
 if ! [ $(id -u) = 0 ]; then
-  bundle config --local path vendor/bundle
+  bundle config set --local path 'vendor/bundle'
   bundle install
   mkdir -p $(bundle exec arduino_library_location.rb)
   cd $(bundle exec arduino_library_location.rb)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-bundle config --local path vendor/bundle
+bundle config set --local path 'vendor/bundle'
 bundle install
 if [ -z "$1" ]; then
   bundle exec arduino_ci.rb --skip-examples-compilation

--- a/scripts/testAndBuild.sh
+++ b/scripts/testAndBuild.sh
@@ -1,4 +1,5 @@
 #! /bin/sh
 bundle config set --local path 'vendor/bundle'
+bundle install
 bundle exec arduino_ci.rb --min-free-space=6000 | tee output.txt
 tail -n 4 output.txt | head -n 2 > size.txt

--- a/scripts/testAndBuild.sh
+++ b/scripts/testAndBuild.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
-bundle install --path vendor/bundle
+bundle config set --local path 'vendor/bundle'
 bundle exec arduino_ci.rb --min-free-space=6000 | tee output.txt
 tail -n 4 output.txt | head -n 2 > size.txt

--- a/size.txt
+++ b/size.txt
@@ -1,2 +1,2 @@
-Sketch uses 72846 bytes (28%) of program storage space. Maximum is 253952 bytes.
-Global variables use 2166 bytes (26%) of dynamic memory, leaving 6026 bytes for local variables. Maximum is 8192 bytes.
+Sketch uses 72742 bytes (28%) of program storage space. Maximum is 253952 bytes.
+Global variables use 2164 bytes (26%) of dynamic memory, leaving 6028 bytes for local variables. Maximum is 8192 bytes.

--- a/size.txt
+++ b/size.txt
@@ -1,2 +1,2 @@
-Sketch uses 72742 bytes (28%) of program storage space. Maximum is 253952 bytes.
-Global variables use 2164 bytes (26%) of dynamic memory, leaving 6028 bytes for local variables. Maximum is 8192 bytes.
+Sketch uses 72846 bytes (28%) of program storage space. Maximum is 253952 bytes.
+Global variables use 2166 bytes (26%) of dynamic memory, leaving 6026 bytes for local variables. Maximum is 8192 bytes.


### PR DESCRIPTION
Now that it supports the faster testing process we can go back to the primary source.