### PR TITLE
Ensure that error gets reported back to arduino_ci

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -104,6 +104,7 @@ OVUV
 pdf
 PGM
 PIDOn
+pipefail
 plugin
 png
 pragma

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -104,7 +104,7 @@ OVUV
 pdf
 PGM
 PIDOn
-pipefail
+PIPESTATUS
 plugin
 png
 pragma

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,7 +2,8 @@
 bundle config set --local path 'vendor/bundle'
 bundle install
 if [ -z "$1" ]; then
-  bundle exec arduino_ci.rb --skip-examples-compilation
+  bundle exec arduino_ci.rb --skip-examples-compilation; result=$?
 else
-  bundle exec arduino_ci.rb --skip-examples-compilation --testfile-select="$1"
+  bundle exec arduino_ci.rb --skip-examples-compilation --testfile-select="$1"; result=$?
 fi
+exit "$result"

--- a/scripts/testAndBuild.sh
+++ b/scripts/testAndBuild.sh
@@ -2,6 +2,6 @@
 bundle config set --local path 'vendor/bundle'
 bundle install
 bundle exec arduino_ci.rb --min-free-space=6000 | tee output.txt
-result=${PIPESTATUS[0]}
+result="${PIPESTATUS[0]}"
 tail -n 4 output.txt | head -n 2 > size.txt
 exit "$result"

--- a/scripts/testAndBuild.sh
+++ b/scripts/testAndBuild.sh
@@ -1,8 +1,7 @@
 #! /bin/sh
 bundle config set --local path 'vendor/bundle'
 bundle install
-set -o pipefail
-bundle exec arduino_ci.rb --min-free-space=6000 | tee output.txt; result=$?
-set +o pipefail
+bundle exec arduino_ci.rb --min-free-space=6000 | tee output.txt
+result=${PIPESTATUS[0]}
 tail -n 4 output.txt | head -n 2 > size.txt
-exit "$result"
+exit $result

--- a/scripts/testAndBuild.sh
+++ b/scripts/testAndBuild.sh
@@ -4,4 +4,4 @@ bundle install
 bundle exec arduino_ci.rb --min-free-space=6000 | tee output.txt
 result=${PIPESTATUS[0]}
 tail -n 4 output.txt | head -n 2 > size.txt
-exit $result
+exit "$result"

--- a/scripts/testAndBuild.sh
+++ b/scripts/testAndBuild.sh
@@ -1,5 +1,8 @@
 #! /bin/sh
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=6000 | tee output.txt
+set -o pipefail
+bundle exec arduino_ci.rb --min-free-space=6000 | tee output.txt; result=$?
+set +o pipefail
 tail -n 4 output.txt | head -n 2 > size.txt
+exit "$result"

--- a/scripts/testAndBuild.sh
+++ b/scripts/testAndBuild.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
 bundle exec arduino_ci.rb --min-free-space=6000 | tee output.txt


### PR DESCRIPTION
Some things we added to our `testAndBuild.sh` script caused it to fail to report the errors.