### PR TITLE
Fix test failures on code.cs

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -139,6 +139,7 @@ snprintf
 solonoids
 src
 stdlib
+strcmp
 strcpy
 strlen
 strncmp
@@ -149,6 +150,7 @@ sudo
 sys
 tankid
 testfile
+theia
 Thu
 timeinfo
 Tmp

--- a/size.txt
+++ b/size.txt
@@ -1,2 +1,2 @@
-Sketch uses 77948 bytes (30%) of program storage space. Maximum is 253952 bytes.
+Sketch uses 77946 bytes (30%) of program storage space. Maximum is 253952 bytes.
 Global variables use 2224 bytes (27%) of dynamic memory, leaving 5968 bytes for local variables. Maximum is 8192 bytes.

--- a/test/SeeFreeMemoryTest.cpp
+++ b/test/SeeFreeMemoryTest.cpp
@@ -18,7 +18,13 @@ unittest(testOutput) {
 
   // Test the output
   assertEqual("Free Memory:    ", display->getLines().at(0));
-  assertEqual("16 bytes        ", display->getLines().at(1));
+  // Handle differences in GitHub vs Theia memory layout
+  String line2 = display->getLines().at(1);
+  const char* line2c = line2.c_str();
+  int githubFlag = strcmp("16 bytes        ", line2c);
+  int theiaFlag = strcmp("64 bytes        ", line2c);
+//   assertEqual("16 bytes        ", display->getLines().at(1));
+  assertTrue(githubFlag == 0 || theiaFlag == 0);
   // Return to mainMenu
   Keypad_TC::instance()->_getPuppet()->push_back('D');
   tc->loop();

--- a/test/SeeFreeMemoryTest.cpp
+++ b/test/SeeFreeMemoryTest.cpp
@@ -23,7 +23,6 @@ unittest(testOutput) {
   const char* line2c = line2.c_str();
   int githubFlag = strcmp("16 bytes        ", line2c);
   int theiaFlag = strcmp("64 bytes        ", line2c);
-//   assertEqual("16 bytes        ", display->getLines().at(1));
   assertTrue(githubFlag == 0 || theiaFlag == 0);
   // Return to mainMenu
   Keypad_TC::instance()->_getPuppet()->push_back('D');

--- a/test/SetTimeTest.cpp
+++ b/test/SetTimeTest.cpp
@@ -9,11 +9,10 @@
 unittest(test) {
   LiquidCrystal_TC* lcd = LiquidCrystal_TC::instance();
   TankController* tc = TankController::instance();
-  SetTime* test = new SetTime(tc);
-  tc->setNextState(test, true);
   DateTime_TC june(2021, 06, 01, 20, 57, 15);
   june.setAsCurrent();
-
+  SetTime* test = new SetTime(tc);
+  tc->setNextState(test, true);
   DateTime_TC now = DateTime_TC::now();
   // the default time is the code compile time
   assertTrue(now.year() == 2021);


### PR DESCRIPTION
Fixes an error in free memory when running test suite on different location (GitHub vs code.cs)
Fixes an error where the rtc on Tank Controller was not being updated before the state was changed.