### PR TITLE
Fix buffer overrun problem

### DIFF
--- a/src/UIState/MainMenu.cpp
+++ b/src/UIState/MainMenu.cpp
@@ -222,7 +222,7 @@ void MainMenu::selectSet() {
 // T=12.25 H 12.75
 void MainMenu::idle() {
   PHControl *phControl = PHControl::instance();
-  char output[17];
+  char output[20];
   output[0] = 'p';
   output[1] = 'H';
   output[2] = millis() / 1000 % 2 ? '=' : ' ';


### PR DESCRIPTION
A pH of 10.000 or more does not print nicely in a space formatted for 5.3.