### PR TITLE
Fix WDT hanging too long on setup

### DIFF
--- a/size.txt
+++ b/size.txt
@@ -1,1 +1,1 @@
-Global variables use 2282 bytes (27%) of dynamic memory, leaving 5910 bytes for local variables. Maximum is 8192 bytes.
+Global variables use 2284 bytes (27%) of dynamic memory, leaving 5908 bytes for local variables. Maximum is 8192 bytes.

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -194,10 +194,9 @@ void TankController::setNextState(UIState *newState, bool update) {
  * Here we do any one-time startup initialization.
  */
 void TankController::setup() {
-  wdt_enable(WDTO_8S);
   serial(F("TankController::setup()"));
-  SD_TC::instance()->printRootDirectory();
   serial(F("Free memory = %i"), freeMemory());
+  wdt_enable(WDTO_8S);
 }
 
 /**


### PR DESCRIPTION
Starts the WDT after printing serial messages in case additional messages that take longer than the WDT failsafe are inserted later.
Removes the printout of the root directory of the SD card.