### PR TITLE
Fix MainMenu excess code; add tests for read/write speeds

### DIFF
--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -207,7 +207,7 @@ void EthernetServer_TC::testReadSpeed() {
   // Read 1 MB
   file = SD_TC::instance()->open(temp, O_READ);
   int startTime = micros();
-  file.read(buffer, 512) == -1); // Flawfinder: ignore
+  file.read(buffer, 512);  // Flawfinder: ignore
   int endTime = micros();
   file.remove();
   serial(F("Time reading 512B: %i us"), (endTime - startTime));
@@ -265,7 +265,7 @@ void EthernetServer_TC::fileSetup() {
 bool EthernetServer_TC::fileContinue() {
   client.write(boundary);
   if (file.available32()) {
-    int readSize = file.read(buffer, sizeof(buffer)); // Flawfinder: ignore
+    int readSize = file.read(buffer, sizeof(buffer));  // Flawfinder: ignore
     int writeSize = client.write(buffer, readSize);
     if (writeSize != readSize) {
       serial(F("read = %d; write = %d"), readSize, writeSize);

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -192,7 +192,7 @@ void EthernetServer_TC::writeToClientBuffer(char* buffer, bool isFinished) {
 }
 
 // Tests speed for reading a file from the SD Card
-// Empirical results show about 12 us per 512 B
+// Empirical results show about 1 ms per 512 B
 void EthernetServer_TC::testReadSpeed() {
   wdt_disable();
   static const char path[] PROGMEM = "tstRdSpd.txt";
@@ -205,7 +205,7 @@ void EthernetServer_TC::testReadSpeed() {
   file.println(buffer);
   file.close();
   // Read 1 MB
-  file = SD_TC::instance()->open(temp, O_READ | O_WRITE);
+  file = SD_TC::instance()->open(temp, O_READ);
   int startTime = micros();
   file.read(buffer, 512);
   int endTime = micros();

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -374,10 +374,12 @@ void EthernetServer_TC::sendFileHeadersWithSize(uint32_t size) {
   // char buffer[sizeof(response)];
   // strncpy_P(buffer, (PGM_P)response, sizeof(buffer));
   // client.write(buffer);
-  snprintf_P(buffer, sizeof(buffer), (PGM_P)F("HTTP/1.1 200 OK\r\n"
-      "Content-Type: multipart/form-data; boundary=%s\r\n"
-      "Access-Control-Allow-Origin: *\r\n"
-      "Content-Length: %lu\r\n"), boundary, (unsigned long)size);
+  snprintf_P(buffer, sizeof(buffer),
+             (PGM_P)F("HTTP/1.1 200 OK\r\n"
+                      "Content-Type: multipart/form-data; boundary=%s\r\n"
+                      "Access-Control-Allow-Origin: *\r\n"
+                      "Content-Length: %lu\r\n"),
+             boundary, (unsigned long)size);
   client.write(buffer);
 
   // blank line indicates end of headers

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -31,7 +31,7 @@ EthernetServer_TC::EthernetServer_TC(uint16_t port) : EthernetServer(port) {
   begin();
   IPAddress IP = Ethernet_TC::instance()->getIP();
   static const char boundary_P[] PROGMEM = "boundary";
-  memcpy(boundary, (PGM_P)boundary_P, sizeof(boundary_P));
+  strncpy_P(boundary, (PGM_P)boundary_P, sizeof(boundary_P));
   serial(F("Ethernet Server is listening on %i.%i.%i.%i:80"), IP[0], IP[1], IP[2], IP[3]);
 }
 

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -207,9 +207,7 @@ void EthernetServer_TC::testReadSpeed() {
   // Read 1 MB
   file = SD_TC::instance()->open(temp, O_READ);
   int startTime = micros();
-  if (file.read(buffer, 512) == -1) {
-    serial(F("Bad read"));
-  };
+  file.read(buffer, 512) == -1); // Flawfinder: ignore
   int endTime = micros();
   file.remove();
   serial(F("Time reading 512B: %i us"), (endTime - startTime));
@@ -267,12 +265,10 @@ void EthernetServer_TC::fileSetup() {
 bool EthernetServer_TC::fileContinue() {
   client.write(boundary);
   if (file.available32()) {
-    int readSize = file.read(buffer, sizeof(buffer));
-    if (readSize != -1) {
-      int writeSize = client.write(buffer, readSize);
-      if (writeSize != readSize) {
-        serial(F("read = %d; write = %d"), readSize, writeSize);
-      }
+    int readSize = file.read(buffer, sizeof(buffer)); // Flawfinder: ignore
+    int writeSize = client.write(buffer, readSize);
+    if (writeSize != readSize) {
+      serial(F("read = %d; write = %d"), readSize, writeSize);
     }
     return false;
   } else {

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -207,7 +207,9 @@ void EthernetServer_TC::testReadSpeed() {
   // Read 1 MB
   file = SD_TC::instance()->open(temp, O_READ);
   int startTime = micros();
-  file.read(buffer, 512);
+  if (file.read(buffer, 512) == -1) {
+    serial(F("Bad read"));
+  };
   int endTime = micros();
   file.remove();
   serial(F("Time reading 512B: %i us"), (endTime - startTime));
@@ -266,9 +268,11 @@ bool EthernetServer_TC::fileContinue() {
   client.write(boundary);
   if (file.available32()) {
     int readSize = file.read(buffer, sizeof(buffer));
-    int writeSize = client.write(buffer, readSize);
-    if (writeSize != readSize) {
-      serial(F("read = %d; write = %d"), readSize, writeSize);
+    if (readSize != -1) {
+      int writeSize = client.write(buffer, readSize);
+      if (writeSize != readSize) {
+        serial(F("read = %d; write = %d"), readSize, writeSize);
+      }
     }
     return false;
   } else {

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -9,7 +9,7 @@
 #include <Ethernet.h>
 #endif
 
-enum serverState_t { NOT_CONNECTED, READ_REQUEST, GET_REQUEST, POST_REQUEST, IN_PROGRESS, FINISHED };
+enum serverState_t { NOT_CONNECTED, READ_REQUEST, GET_REQUEST, POST_REQUEST, IN_PROGRESS, IN_TRANSFER, FINISHED };
 
 /**
  * EthernetServer_TC provides wrapper for web server for TankController
@@ -28,7 +28,7 @@ public:
     return state;
   }
   void loop();
-  void writeBufferToClient(char*, bool);
+  void writeToClientBuffer(char*, bool);
 
 private:
   // class variables
@@ -38,23 +38,32 @@ private:
   EthernetClient client;
   serverState_t state = NOT_CONNECTED;
   char buffer[512];
+  char boundary[13];
   unsigned int bufferContentsSize = 0;
   unsigned long connectedAt = 0;
+  File file;
+  int startTime;
 
   // instance methods: constructor
   EthernetServer_TC(uint16_t port);
   // instance methods: utility
   void sendHeadersWithSize(uint32_t size);
+  void sendFileHeadersWithSize(uint32_t size);
   void sendRedirectHeaders();
   void sendBadRequestHeaders();
   int weekday(int year, int month, int day);
   // instance methods: HTTP
+  void get();
+  void post();
   void echo();
+  void apiHandler();
   void current();
   void display();
   void keypress();
   void rootdir();
-  bool file();
-  void get();
-  void post();
+  void testReadSpeed();
+  void testWriteSpeed();
+  bool isFileRequest();
+  void fileSetup();
+  bool fileContinue();
 };

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -38,7 +38,7 @@ private:
   EthernetClient client;
   serverState_t state = NOT_CONNECTED;
   char buffer[512];
-  char boundary[13];
+  char boundary[9];
   unsigned int bufferContentsSize = 0;
   unsigned long connectedAt = 0;
   File file;

--- a/src/Devices/LiquidCrystal_TC.cpp
+++ b/src/Devices/LiquidCrystal_TC.cpp
@@ -48,6 +48,10 @@ void LiquidCrystal_TC::splashScreen(const char* version) {
  */
 void LiquidCrystal_TC::writeLine(const char* text, uint16_t line) {
   line = line % 2;
+  // Avoid printing again if same data
+  if (memcmp(text, _lines[line], 16) == 0) {
+    return;
+  }
   setCursor(0, line);
   char* result = _lines[line];
   bool moreText = true;

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -156,8 +156,9 @@ void SD_TC::listFiles(void (*callWhenFull)(char*, bool), byte tabulation) {
           // Now we change parent directory
           parent = &hierarchy[hierarchySize - 1];
         } else {
-          int bytesWritten = snprintf_P(buffer + linePos, sizeof(buffer) - linePos, (PGM_P)F("%s\t%6u bytes\n"),
-                                        fileName, current.fileSize());
+          // We'll say nothing is bigger than 10 MB
+          int bytesWritten = snprintf_P(buffer + linePos, sizeof(buffer) - linePos, (PGM_P)F("%s\t%10lu B\n"), fileName,
+                                        (unsigned long)current.size());
           // "Overwrite" null terminator
           linePos += bytesWritten;
           ++filesWritten;

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -143,7 +143,7 @@ void TankController::handleUI() {
 /**
  * This is one of two public instance functions.
  * It is called repeatedly while the board is on.
- * (It appears to be called about once every 15 ms.)
+ * (loop() appears to finish in 2-4 ms idling at main menu.)
  */
 void TankController::loop() {
   wdt_reset();

--- a/src/TankController.h
+++ b/src/TankController.h
@@ -40,7 +40,6 @@ private:
   UIState* nextState = nullptr;
   uint32_t lastKeypadTime = 0;
   char nextKey = 0;
-  int counter = 0;
 
   // instance methods
   TankController();

--- a/src/TankController.h
+++ b/src/TankController.h
@@ -40,6 +40,7 @@ private:
   UIState* nextState = nullptr;
   uint32_t lastKeypadTime = 0;
   char nextKey = 0;
+  int counter = 0;
 
   // instance methods
   TankController();

--- a/src/UIState/MainMenu.cpp
+++ b/src/UIState/MainMenu.cpp
@@ -236,7 +236,9 @@ void MainMenu::selectSet() {
 // pH=7.325 B 7.125
 // T=12.25 H 12.75
 void MainMenu::idle() {
-  if (millis() - lastDisplayTime > 1000) {
+  // This appears to take 6 ms with all its calculations,
+  // including LCD's ignoring duplicate results
+  if (millis() - lastDisplayTime > 200) {
     PHControl *phControl = PHControl::instance();
     char output[20];
     output[0] = 'p';

--- a/src/UIState/MainMenu.cpp
+++ b/src/UIState/MainMenu.cpp
@@ -236,37 +236,40 @@ void MainMenu::selectSet() {
 // pH=7.325 B 7.125
 // T=12.25 H 12.75
 void MainMenu::idle() {
-  PHControl *phControl = PHControl::instance();
-  char output[20];
-  output[0] = 'p';
-  output[1] = 'H';
-  output[2] = millis() / 1000 % 2 ? '=' : ' ';
-  dtostrf(PHProbe::instance()->getPh(), 5, 3, output + 3);
-  output[8] = ' ';
-  output[9] = phControl->isOn() ? 'B' : ' ';
-  output[10] = ' ';
-  dtostrf(PHControl::instance()->getTargetPh(), 5, 3, output + 11);
-  LiquidCrystal_TC::instance()->writeLine(output, 0);
-  TemperatureControl *tempControl = TemperatureControl::instance();
-  TempProbe_TC *tempProbe = TempProbe_TC::instance();
-  float temp = tempProbe->getRunningAverage();
-  if (temp < 0.0) {
-    temp = 0.0;
-  } else if (99.99 < temp) {
-    temp = 99.99;
+  if (millis() - lastDisplayTime > 1000) {
+    PHControl *phControl = PHControl::instance();
+    char output[20];
+    output[0] = 'p';
+    output[1] = 'H';
+    output[2] = millis() / 1000 % 2 ? '=' : ' ';
+    dtostrf(PHProbe::instance()->getPh(), 5, 3, output + 3);
+    output[8] = ' ';
+    output[9] = phControl->isOn() ? 'B' : ' ';
+    output[10] = ' ';
+    dtostrf(PHControl::instance()->getTargetPh(), 5, 3, output + 11);
+    LiquidCrystal_TC::instance()->writeLine(output, 0);
+    TemperatureControl *tempControl = TemperatureControl::instance();
+    TempProbe_TC *tempProbe = TempProbe_TC::instance();
+    float temp = tempProbe->getRunningAverage();
+    if (temp < 0.0) {
+      temp = 0.0;
+    } else if (99.99 < temp) {
+      temp = 99.99;
+    }
+    char status = tempControl->isHeater() ? 'h' : 'c';
+    if (tempControl->isOn()) {
+      status = toupper(status);
+    }
+    output[0] = 'T';
+    output[1] = millis() / 1000 % 2 ? '=' : ' ';
+    dtostrf(temp, 5, 2, output + 2);
+    output[7] = ' ';
+    output[8] = status;
+    output[9] = ' ';
+    dtostrf(tempControl->getTargetTemperature(), 5, 2, output + 10);
+    LiquidCrystal_TC::instance()->writeLine(output, 1);
+    lastDisplayTime = millis();
   }
-  char status = tempControl->isHeater() ? 'h' : 'c';
-  if (tempControl->isOn()) {
-    status = toupper(status);
-  }
-  output[0] = 'T';
-  output[1] = millis() / 1000 % 2 ? '=' : ' ';
-  dtostrf(temp, 5, 2, output + 2);
-  output[7] = ' ';
-  output[8] = status;
-  output[9] = ' ';
-  dtostrf(tempControl->getTargetTemperature(), 5, 2, output + 10);
-  LiquidCrystal_TC::instance()->writeLine(output, 1);
 }
 
 void MainMenu::loop() {

--- a/src/UIState/MainMenu.cpp
+++ b/src/UIState/MainMenu.cpp
@@ -236,42 +236,44 @@ void MainMenu::selectSet() {
 // pH=7.325 B 7.125
 // T=12.25 H 12.75
 void MainMenu::idle() {
+  // guard clause to only update LCD 5 times per second
+  if (millis() - lastDisplayTime < 200) {
+    return;
+  }
   // This appears to take 6 ms with all its calculations,
   // including LCD's ignoring duplicate results
-  if (millis() - lastDisplayTime > 200) {
-    PHControl *phControl = PHControl::instance();
-    char output[20];
-    output[0] = 'p';
-    output[1] = 'H';
-    output[2] = millis() / 1000 % 2 ? '=' : ' ';
-    dtostrf(PHProbe::instance()->getPh(), 5, 3, output + 3);
-    output[8] = ' ';
-    output[9] = phControl->isOn() ? 'B' : ' ';
-    output[10] = ' ';
-    dtostrf(PHControl::instance()->getTargetPh(), 5, 3, output + 11);
-    LiquidCrystal_TC::instance()->writeLine(output, 0);
-    TemperatureControl *tempControl = TemperatureControl::instance();
-    TempProbe_TC *tempProbe = TempProbe_TC::instance();
-    float temp = tempProbe->getRunningAverage();
-    if (temp < 0.0) {
-      temp = 0.0;
-    } else if (99.99 < temp) {
-      temp = 99.99;
-    }
-    char status = tempControl->isHeater() ? 'h' : 'c';
-    if (tempControl->isOn()) {
-      status = toupper(status);
-    }
-    output[0] = 'T';
-    output[1] = millis() / 1000 % 2 ? '=' : ' ';
-    dtostrf(temp, 5, 2, output + 2);
-    output[7] = ' ';
-    output[8] = status;
-    output[9] = ' ';
-    dtostrf(tempControl->getTargetTemperature(), 5, 2, output + 10);
-    LiquidCrystal_TC::instance()->writeLine(output, 1);
-    lastDisplayTime = millis();
+  PHControl *phControl = PHControl::instance();
+  char output[20];
+  output[0] = 'p';
+  output[1] = 'H';
+  output[2] = millis() / 1000 % 2 ? '=' : ' ';
+  dtostrf(PHProbe::instance()->getPh(), 5, 3, output + 3);
+  output[8] = ' ';
+  output[9] = phControl->isOn() ? 'B' : ' ';
+  output[10] = ' ';
+  dtostrf(PHControl::instance()->getTargetPh(), 5, 3, output + 11);
+  LiquidCrystal_TC::instance()->writeLine(output, 0);
+  TemperatureControl *tempControl = TemperatureControl::instance();
+  TempProbe_TC *tempProbe = TempProbe_TC::instance();
+  float temp = tempProbe->getRunningAverage();
+  if (temp < 0.0) {
+    temp = 0.0;
+  } else if (99.99 < temp) {
+    temp = 99.99;
   }
+  char status = tempControl->isHeater() ? 'h' : 'c';
+  if (tempControl->isOn()) {
+    status = toupper(status);
+  }
+  output[0] = 'T';
+  output[1] = millis() / 1000 % 2 ? '=' : ' ';
+  dtostrf(temp, 5, 2, output + 2);
+  output[7] = ' ';
+  output[8] = status;
+  output[9] = ' ';
+  dtostrf(tempControl->getTargetTemperature(), 5, 2, output + 10);
+  LiquidCrystal_TC::instance()->writeLine(output, 1);
+  lastDisplayTime = millis();
 }
 
 void MainMenu::loop() {

--- a/src/UIState/MainMenu.h
+++ b/src/UIState/MainMenu.h
@@ -60,6 +60,8 @@ public:
 private:
   int16_t level1 = 0;
   int16_t level2 = -1;
+  // So we'll immediately update display
+  unsigned long lastDisplayTime = -1000;
   const __FlashStringHelper* viewMenus[VIEW_COMMAND_COUNT];
   const __FlashStringHelper* setMenus[SET_COMMAND_COUNT];
   void left();


### PR DESCRIPTION
MainMenu's `idle()` function was calculating values every loop instead of every second, so now `TankController::loop()` executes in 2-4 ms at MainMenu idle.

This also has comments that document experimental speeds for reading from the SD card and writing to the client, in cases for handling file transfer.

This also refactors the file transfer protocol to be non-blocking and is transmitted as multipart data rather than text.