### PR TITLE
Press '#' to disable the Watchdog Timer

### DIFF
--- a/src/UIState/SeeDeviceAddress.cpp
+++ b/src/UIState/SeeDeviceAddress.cpp
@@ -12,6 +12,9 @@
 
 void SeeDeviceAddress::handleKey(char key) {
   switch (key) {
+    case '#':  // Disable Watchdog Timer (is reboot from this?)
+      wdt_disable();
+      break;
     case 'B':  // Infinite loop to test Watchdog Timer
       wdt_disable();
       wdt_enable(WDTO_15MS);


### PR DESCRIPTION
When viewing the device address (then reset to enable it).