### PR TITLE
Listing files with valid HTTP header

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TankController
-version=22.7.2
+version=22.8.1
 author=Kirt Onthank <Kirt.Onthank@wallawalla.edu>, Preston Carman <prestonc@apache.org>, James Foster <github@jgfoster.net>
 maintainer=James Foster <github@jgfoster.net>
 sentence=Software for the Arduino that controls pH and temperature in the Open-Acidification project.

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -180,18 +180,24 @@ void countFilesCallback(int fileCount) {
 
 // List the root directory to the client
 void EthernetServer_TC::rootdir() {
+  std::cout << "rootdir-1" << std::endl;
   // Call function on SD Card
   // Provide callback to call when writing to the client buffer
   if (state != LISTING_FILES) {
+    std::cout << "rootdir-2" << std::endl;
     state = LISTING_FILES;
     isDoneCountingFiles = false;
     startTime = millis();
     serial(F("Preparing list of files in root directory..."));
   } else {
     if (isDoneCountingFiles) {
+      std::cout << "rootdir-5" << std::endl;
       SD_TC::instance()->listRootToBuffer(writeToClientBufferCallback);
+      std::cout << "rootdir-6" << std::endl;
     } else {
+      std::cout << "rootdir-3" << std::endl;
       SD_TC::instance()->countFiles(countFilesCallback);
+      std::cout << "rootdir-4" << std::endl;
     }
   }
 }

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -182,7 +182,7 @@ void countFilesCallback(int fileCount) {
 void EthernetServer_TC::rootdir() {
   // Call function on SD Card
   // Provide callback to call when writing to the client buffer
-  if(state != LISTING_FILES) {
+  if (state != LISTING_FILES) {
     state = LISTING_FILES;
     isDoneCountingFiles = false;
     startTime = millis();
@@ -212,8 +212,8 @@ void EthernetServer_TC::writeToClientBuffer(char* buffer, bool isFinished) {
 void EthernetServer_TC::sendHeadersForRootdir(int fileCount) {
   isDoneCountingFiles = true;
   serial(F("...%i files..."), fileCount);
-  sendHeadersWithSize((uint32_t) fileCount * 24); // 24 characters per line
-  state = LISTING_FILES; // TODO: This is here only because sendHeadersWithSize() changes the state prematurely.
+  sendHeadersWithSize((uint32_t)fileCount * 24);  // 24 characters per line
+  state = LISTING_FILES;  // TODO: This is here only because sendHeadersWithSize() changes the state prematurely.
 }
 
 // Tests speed for reading a file from the SD Card
@@ -394,7 +394,7 @@ void EthernetServer_TC::sendHeadersWithSize(uint32_t size) {
   // blank line indicates end of headers
   client.write('\r');
   client.write('\n');
-  state = FINISHED; // TODO: Why?! This is awkward when we want to send a body next.
+  state = FINISHED;  // TODO: Why?! This is awkward when we want to send a body next.
 }
 
 // 303 response

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -180,28 +180,22 @@ void countFilesCallback(int fileCount) {
 
 // List the root directory to the client
 void EthernetServer_TC::rootdir() {
-  std::cout << "rootdir-1" << std::endl;
   // Call function on SD Card
   // Provide callback to call when writing to the client buffer
   if (state != LISTING_FILES) {
-    std::cout << "rootdir-2" << std::endl;
     state = LISTING_FILES;
     isDoneCountingFiles = false;
     startTime = millis();
     serial(F("Preparing list of files in root directory..."));
   } else {
     if (isDoneCountingFiles) {
-      std::cout << "rootdir-5" << std::endl;
       SD_TC::instance()->listRootToBuffer(writeToClientBufferCallback);
-      std::cout << "rootdir-6" << std::endl;
     } else {
-      std::cout << "rootdir-3" << std::endl;
 #ifndef MOCK_PINS_COUNT
       SD_TC::instance()->countFiles(countFilesCallback);
 #else
       countFilesCallback(0);
 #endif
-      std::cout << "rootdir-4" << std::endl;
     }
   }
 }

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -216,6 +216,7 @@ void EthernetServer_TC::sendHeadersForRootdir(int fileCount) {
   sendHeadersWithSize((uint32_t)fileCount * 24);  // 24 characters per line
   state = LISTING_FILES;  // TODO: This is here only because sendHeadersWithSize() changes the state prematurely.
 #else
+  isDoneCountingFiles = true;
   sendHeadersWithSize((uint32_t)49);
   state = LISTING_FILES;
 #endif

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -216,7 +216,7 @@ void EthernetServer_TC::sendHeadersForRootdir(int fileCount) {
   sendHeadersWithSize((uint32_t)fileCount * 24);  // 24 characters per line
   state = LISTING_FILES;  // TODO: This is here only because sendHeadersWithSize() changes the state prematurely.
 #else
-  sendHeadersWithSize(49);
+  sendHeadersWithSize((uint32_t)49);
   state = LISTING_FILES;
 #endif
 }

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -185,6 +185,8 @@ void EthernetServer_TC::rootdir() {
   if(state != LISTING_FILES) {
     state = LISTING_FILES;
     isDoneCountingFiles = false;
+    startTime = millis();
+    serial(F("Preparing list of files in root directory..."));
   } else {
     if (isDoneCountingFiles) {
       SD_TC::instance()->listRootToBuffer(writeToClientBufferCallback);
@@ -201,12 +203,15 @@ void EthernetServer_TC::writeToClientBuffer(char* buffer, bool isFinished) {
   if (isFinished) {
     client.write('\r');
     client.write('\n');
+    int endTime = millis();
+    serial(F("...Done sending, time = %i ms"), endTime - startTime);
     state = FINISHED;
   }
 }
 
 void EthernetServer_TC::sendHeadersForRootdir(int fileCount) {
   isDoneCountingFiles = true;
+  serial(F("...%i files..."), fileCount);
   sendHeadersWithSize((uint32_t) fileCount * 24); // 24 characters per line
   state = LISTING_FILES; // TODO: This is here only because sendHeadersWithSize() changes the state prematurely.
 }

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -196,7 +196,11 @@ void EthernetServer_TC::rootdir() {
       std::cout << "rootdir-6" << std::endl;
     } else {
       std::cout << "rootdir-3" << std::endl;
+#ifndef MOCK_PINS_COUNT
       SD_TC::instance()->countFiles(countFilesCallback);
+#else
+      countFilesCallback(0);
+#endif
       std::cout << "rootdir-4" << std::endl;
     }
   }

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -210,10 +210,15 @@ void EthernetServer_TC::writeToClientBuffer(char* buffer, bool isFinished) {
 }
 
 void EthernetServer_TC::sendHeadersForRootdir(int fileCount) {
+#ifndef MOCK_PINS_COUNT
   isDoneCountingFiles = true;
   serial(F("...%i files..."), fileCount);
   sendHeadersWithSize((uint32_t)fileCount * 24);  // 24 characters per line
   state = LISTING_FILES;  // TODO: This is here only because sendHeadersWithSize() changes the state prematurely.
+#else
+  sendHeadersWithSize(49);
+  state = LISTING_FILES;
+#endif
 }
 
 // Tests speed for reading a file from the SD Card

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -44,7 +44,7 @@ private:
   unsigned long connectedAt = 0;
   File file;
   int startTime;
-  bool isDoneCountingFiles = true;
+  bool isDoneCountingFiles = true;  // TODO: Perhaps replace this with a new COUNTING_FILES state
 
   // instance methods: constructor
   EthernetServer_TC(uint16_t port);

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -9,7 +9,7 @@
 #include <Ethernet.h>
 #endif
 
-enum serverState_t { NOT_CONNECTED, READ_REQUEST, GET_REQUEST, POST_REQUEST, IN_PROGRESS, IN_TRANSFER, FINISHED };
+enum serverState_t { NOT_CONNECTED, READ_REQUEST, GET_REQUEST, POST_REQUEST, LISTING_FILES, IN_TRANSFER, FINISHED };
 
 /**
  * EthernetServer_TC provides wrapper for web server for TankController
@@ -29,6 +29,7 @@ public:
   }
   void loop();
   void writeToClientBuffer(char*, bool);
+  void sendHeadersForRootdir(int);
 
 private:
   // class variables
@@ -43,6 +44,7 @@ private:
   unsigned long connectedAt = 0;
   File file;
   int startTime;
+  bool isDoneCountingFiles = true;
 
   // instance methods: constructor
   EthernetServer_TC(uint16_t port);
@@ -62,7 +64,6 @@ private:
   void rootdir();
   void testReadSpeed();
   void testWriteSpeed();
-  void countTimer();
   bool isRequestForExistingFile();
   void fileSetup();
   bool fileContinue();

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -48,7 +48,6 @@ private:
   EthernetServer_TC(uint16_t port);
   // instance methods: utility
   void sendHeadersWithSize(uint32_t size);
-  void sendFileHeadersWithSize(uint32_t size);
   void sendRedirectHeaders();
   void sendBadRequestHeaders();
   int weekday(int year, int month, int day);
@@ -63,6 +62,7 @@ private:
   void rootdir();
   void testReadSpeed();
   void testWriteSpeed();
+  void countTimer();
   bool isRequestForExistingFile();
   void fileSetup();
   bool fileContinue();

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -142,17 +142,17 @@ void SD_TC::countFiles(void (*callWhenFinished)(int)) {
 }
 
 struct listFilesData_t {
-  void (*callWhenFull)(char*, bool);
-  char buffer[250];  // Each line should be 24 characters long; 10 lines
-  int linePos;
-  int filesWritten;
+  // Each line should be 24 characters long; 10 lines
+  char buffer[250];  // Flawfinder: ignore
+  int linePos;       // Flawfinder: ignore
+  int filesWritten;  // Flawfinder: ignore
 };
 
 // Issue: This function does not visually display depth for items in subfolders
 // With maxDepth set to 2, no subfolders are traversed
 bool SD_TC::listFile(File* myFile, void* userData) {
 #ifndef MOCK_PINS_COUNT
-  listFilesData_t* pListFileData = (listFilesData_t*)userData;
+  listFilesData_t* pListFileData = (listFilesData_t*)userData;  // Flawfinder: ignore
   char fileName[15];
   myFile->getName(fileName, sizeof(fileName));
   int bytesWritten;

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -187,10 +187,6 @@ void SD_TC::listRootToBuffer(void (*callWhenFull)(char*, bool)) {
   listFileData.buffer[listFileData.linePos] = '\0';
   callWhenFull(listFileData.buffer, !inProgress);
 #else
-  listFilesData_t listFileData;
-  listFileData.linePos = 0;
-  listFileData.filesWritten = 0;
-  listFileData.buffer[0] = '\0';
   static const char notImplemented[] PROGMEM = "Root directory not supported by CI framework.\r\n";
   char buffer[sizeof(notImplemented)];
   memcpy(buffer, (PGM_P)notImplemented, sizeof(notImplemented));

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -123,6 +123,7 @@ bool SD_TC::incrementFileCount(File* myFile, void* pFileCount) {
 }
 
 void SD_TC::countFiles(void (*callWhenFinished)(int)) {
+#ifndef MOCK_PINS_COUNT
   if (!inProgress) {
     const char path[] PROGMEM = "/";
     fileStack[0] = SD_TC::instance()->open(path);
@@ -139,6 +140,9 @@ void SD_TC::countFiles(void (*callWhenFinished)(int)) {
   if (!inProgress) {
     callWhenFinished(fileCount);
   }
+#else
+  callWhenFinished(49);
+#endif
 }
 
 struct listFilesData_t {

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -143,16 +143,16 @@ void SD_TC::countFiles(void (*callWhenFinished)(int)) {
 
 struct listFilesData_t {
   // Each line should be 24 characters long; 10 lines
-  char buffer[250];  // Flawfinder: ignore
-  int linePos;       // Flawfinder: ignore
-  int filesWritten;  // Flawfinder: ignore
+  char buffer[250];  // cppcheck-suppress "unusedStructMember"
+  int linePos;       // cppcheck-suppress "unusedStructMember"
+  int filesWritten;  // cppcheck-suppress "unusedStructMember"
 };
 
 // Issue: This function does not visually display depth for items in subfolders
 // With maxDepth set to 2, no subfolders are traversed
 bool SD_TC::listFile(File* myFile, void* userData) {
 #ifndef MOCK_PINS_COUNT
-  listFilesData_t* pListFileData = (listFilesData_t*)userData;  // Flawfinder: ignore
+  listFilesData_t* pListFileData = static_cast<listFilesData_t*>(userData);
   char fileName[15];
   myFile->getName(fileName, sizeof(fileName));
   int bytesWritten;

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -194,6 +194,10 @@ void SD_TC::listRootToBuffer(void (*callWhenFull)(char*, bool)) {
   listFileData.buffer[listFileData.linePos] = '\0';
   callWhenFull(listFileData.buffer, !inProgress);
 #else
+  listFilesData_t listFileData;
+  listFileData.linePos = 0;
+  listFileData.filesWritten = 0;
+  listFileData.buffer[0] = '\0';
   static const char notImplemented[] PROGMEM = "Root directory not supported by CI framework.\r\n";
   char buffer[sizeof(notImplemented)];
   memcpy(buffer, (PGM_P)notImplemented, sizeof(notImplemented));

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -141,13 +141,6 @@ void SD_TC::countFiles(void (*callWhenFinished)(int)) {
   }
 }
 
-struct listFilesData_t {
-  // Each line should be 24 characters long; 10 lines
-  char buffer[250];  // cppcheck-suppress "unusedStructMember"
-  int linePos;       // cppcheck-suppress "unusedStructMember"
-  int filesWritten;  // cppcheck-suppress "unusedStructMember"
-};
-
 // Issue: This function does not visually display depth for items in subfolders
 // With maxDepth set to 2, no subfolders are traversed
 bool SD_TC::listFile(File* myFile, void* userData) {

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -123,7 +123,6 @@ bool SD_TC::incrementFileCount(File* myFile, void* pFileCount) {
 }
 
 void SD_TC::countFiles(void (*callWhenFinished)(int)) {
-#ifndef MOCK_PINS_COUNT
   if (!inProgress) {
     const char path[] PROGMEM = "/";
     fileStack[0] = SD_TC::instance()->open(path);
@@ -140,9 +139,6 @@ void SD_TC::countFiles(void (*callWhenFinished)(int)) {
   if (!inProgress) {
     callWhenFinished(fileCount);
   }
-#else
-  callWhenFinished(49);
-#endif
 }
 
 struct listFilesData_t {
@@ -161,13 +157,13 @@ bool SD_TC::listFile(File* myFile, void* userData) {
   myFile->getName(fileName, sizeof(fileName));
   int bytesWritten;
   if (myFile->isDir()) {
-    bytesWritten = snprintf_P(pListFileData->buffer + pListFileData->linePos, 
-                              sizeof(pListFileData->buffer) - pListFileData->linePos, 
+    bytesWritten = snprintf_P(pListFileData->buffer + pListFileData->linePos,
+                              sizeof(pListFileData->buffer) - pListFileData->linePos,
                               (PGM_P)F("%11.11s/          \r\n"), fileName);
   } else {
-    bytesWritten = snprintf_P(pListFileData->buffer + pListFileData->linePos, 
-                              sizeof(pListFileData->buffer) - pListFileData->linePos, 
-                              (PGM_P)F("%s\t%6u KB\r\n"), fileName, myFile->fileSize() / 1024 + 1);
+    bytesWritten = snprintf_P(pListFileData->buffer + pListFileData->linePos,
+                              sizeof(pListFileData->buffer) - pListFileData->linePos, (PGM_P)F("%s\t%6u KB\r\n"),
+                              fileName, myFile->fileSize() / 1024 + 1);
   }
   // "Overwrite" null terminator
   pListFileData->linePos += bytesWritten;

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -96,7 +96,9 @@ bool SD_TC::iterateOnFiles(doOnFile functionName, void* userData) {
         if (fileStack[fileStackSize].isDir()) {
           // maxDepth was set to 2 in SD_TC.h
           // So this code is untested
-          if(fileStackSize < maxDepth - 1) {++fileStackSize;};
+          if (fileStackSize < maxDepth - 1) {
+            ++fileStackSize;
+          };
         } else {
           // Close current file; directories are closed later
           fileStack[fileStackSize].close();
@@ -106,18 +108,18 @@ bool SD_TC::iterateOnFiles(doOnFile functionName, void* userData) {
       // We're done with a directory
       fileStack[--fileStackSize].close();
       if (fileStackSize == 0) {
-        return false; // Done with root---there are no more files
+        return false;  // Done with root---there are no more files
       }
     }
   }
-  return true; // There are (probably) more files remaining
+  return true;  // There are (probably) more files remaining
 #else
   return false;
 #endif
 }
 
 bool SD_TC::incrementFileCount(File* myFile, void* pFileCount) {
-  return ++(*(int*)pFileCount) % 10 != 0; // Pause after counting 10 files
+  return ++(*(int*)pFileCount) % 10 != 0;  // Pause after counting 10 files
 }
 
 void SD_TC::countFiles(void (*callWhenFinished)(int)) {
@@ -141,7 +143,7 @@ void SD_TC::countFiles(void (*callWhenFinished)(int)) {
 
 struct listFilesData_t {
   void (*callWhenFull)(char*, bool);
-  char buffer[250]; // Each line should be 24 characters long; 10 lines
+  char buffer[250];  // Each line should be 24 characters long; 10 lines
   int linePos;
   int filesWritten;
 };
@@ -150,22 +152,22 @@ struct listFilesData_t {
 // With maxDepth set to 2, no subfolders are traversed
 bool SD_TC::listFile(File* myFile, void* userData) {
 #ifndef MOCK_PINS_COUNT
-  listFilesData_t* pListFileData = (listFilesData_t*) userData;
+  listFilesData_t* pListFileData = (listFilesData_t*)userData;
   char fileName[15];
   myFile->getName(fileName, sizeof(fileName));
   int bytesWritten;
   if (myFile->isDir()) {
     bytesWritten = snprintf_P(pListFileData->buffer + pListFileData->linePos, 
-      sizeof(pListFileData->buffer) - pListFileData->linePos, 
-      (PGM_P)F("%11.11s/          \r\n"), fileName);
+                              sizeof(pListFileData->buffer) - pListFileData->linePos, 
+                              (PGM_P)F("%11.11s/          \r\n"), fileName);
   } else {
     bytesWritten = snprintf_P(pListFileData->buffer + pListFileData->linePos, 
-      sizeof(pListFileData->buffer) - pListFileData->linePos, 
-      (PGM_P)F("%s\t%6u KB\r\n"), fileName, myFile->fileSize() / 1024 + 1);
+                              sizeof(pListFileData->buffer) - pListFileData->linePos, 
+                              (PGM_P)F("%s\t%6u KB\r\n"), fileName, myFile->fileSize() / 1024 + 1);
   }
   // "Overwrite" null terminator
   pListFileData->linePos += bytesWritten;
-  return (++(pListFileData->filesWritten)) % 10 != 0; // Stop iterating after 10 files
+  return (++(pListFileData->filesWritten)) % 10 != 0;  // Stop iterating after 10 files
 #else
   return false;
 #endif

--- a/src/Devices/SD_TC.h
+++ b/src/Devices/SD_TC.h
@@ -9,10 +9,9 @@
 typedef bool (*doOnFile)(File*, void*);
 
 struct listFilesData_t {
-  // Each line should be 24 characters long; 10 lines
-  char buffer[250];  // cppcheck-suppress "unusedStructMember"
-  int linePos;       // cppcheck-suppress "unusedStructMember"
-  int filesWritten;  // cppcheck-suppress "unusedStructMember"
+  char buffer[250];  // Each line should be 24 characters long; 10 lines
+  int linePos;
+  int filesWritten;
 };
 
 class SD_TC {

--- a/src/Devices/SD_TC.h
+++ b/src/Devices/SD_TC.h
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 
+#define maxDepth 2
 #define SS 4
 #include <SdFat.h>
 
@@ -37,7 +38,6 @@ private:
   // Max depth of file system search for rootdir()
   // Two is minimum: First for root, second for files
   // Each is 64 bytes
-  #define maxDepth 2 
   File fileStack[maxDepth];
   int fileStackSize;
   int fileCount;

--- a/src/Devices/SD_TC.h
+++ b/src/Devices/SD_TC.h
@@ -18,7 +18,7 @@ public:
   bool exists(const char* path);
   bool format();
   void listRootToBuffer(void (*callWhenFull)(char*, bool));
-  int countFiles();
+  void countFiles(void (*callWhenFinished)(int));
   bool mkdir(const char* path);
   File open(const char* path, oflag_t oflag = 0x00);
   void printRootDirectory();
@@ -33,10 +33,14 @@ private:
   const uint8_t SD_SELECT_PIN = SS;
   bool hasHadError = false;
   SdFat sd;
-  #define maxDepth 1 /* Max depth of folders to list in rootdir(). Each is 64 bytes */
+
+  // Max depth of file system search for rootdir()
+  // Two is minimum: First for root, second for files
+  // Each is 64 bytes
+  #define maxDepth 2 
   File fileStack[maxDepth];
   int fileStackSize;
-  // int fileCount;
+  int fileCount;
   bool inProgress = false;
 
   // instance methods
@@ -45,5 +49,4 @@ private:
   bool iterateOnFiles(doOnFile functionName, void* userData);
   static bool incrementFileCount(File* myFile, void* pFileCount);
   static bool listFile(File* myFile, void* userData);
-  // void listFiles(void (*callWhenFull)(char*, bool));
 };

--- a/src/Devices/SD_TC.h
+++ b/src/Devices/SD_TC.h
@@ -5,7 +5,7 @@
 #define SS 4
 #include <SdFat.h>
 
-typedef void (*doOnFile)(File*);
+typedef bool (*doOnFile)(File*, void*);
 
 class SD_TC {
 public:
@@ -33,15 +33,17 @@ private:
   const uint8_t SD_SELECT_PIN = SS;
   bool hasHadError = false;
   SdFat sd;
-  const int maxDepth = 3; // Max depth of folders to list in rootdir()
-  File fileStack[3]; // Agrees with maxDepth above. Each is 64 bytes
+  #define maxDepth 1 /* Max depth of folders to list in rootdir(). Each is 64 bytes */
+  File fileStack[maxDepth];
   int fileStackSize;
+  // int fileCount;
   bool inProgress = false;
 
   // instance methods
   SD_TC();
   void appendDataToPath(const char* data, const char* path);
-  void listFiles(void (*callWhenFull)(char*, bool), byte tabulation = 0);
-  void iterateOnFiles(doOnFile functionName);
-  static void incrementFileCount(File* myFile);
+  bool iterateOnFiles(doOnFile functionName, void* userData);
+  static bool incrementFileCount(File* myFile, void* pFileCount);
+  static bool listFile(File* myFile, void* userData);
+  // void listFiles(void (*callWhenFull)(char*, bool));
 };

--- a/src/Devices/SD_TC.h
+++ b/src/Devices/SD_TC.h
@@ -8,6 +8,13 @@
 
 typedef bool (*doOnFile)(File*, void*);
 
+struct listFilesData_t {
+  // Each line should be 24 characters long; 10 lines
+  char buffer[250];  // cppcheck-suppress "unusedStructMember"
+  int linePos;       // cppcheck-suppress "unusedStructMember"
+  int filesWritten;  // cppcheck-suppress "unusedStructMember"
+};
+
 class SD_TC {
 public:
   // class methods

--- a/src/Devices/SD_TC.h
+++ b/src/Devices/SD_TC.h
@@ -5,6 +5,8 @@
 #define SS 4
 #include <SdFat.h>
 
+typedef void (*doOnFile)(File*);
+
 class SD_TC {
 public:
   // class methods
@@ -16,6 +18,7 @@ public:
   bool exists(const char* path);
   bool format();
   void listRootToBuffer(void (*callWhenFull)(char*, bool));
+  int countFiles();
   bool mkdir(const char* path);
   File open(const char* path, oflag_t oflag = 0x00);
   void printRootDirectory();
@@ -30,12 +33,15 @@ private:
   const uint8_t SD_SELECT_PIN = SS;
   bool hasHadError = false;
   SdFat sd;
-  File* hierarchy = nullptr;
-  int hierarchySize = 0;
+  const int maxDepth = 3; // Max depth of folders to list in rootdir()
+  File fileStack[3]; // Agrees with maxDepth above. Each is 64 bytes
+  int fileStackSize;
   bool inProgress = false;
 
   // instance methods
   SD_TC();
   void appendDataToPath(const char* data, const char* path);
   void listFiles(void (*callWhenFull)(char*, bool), byte tabulation = 0);
+  void iterateOnFiles(doOnFile functionName);
+  static void incrementFileCount(File* myFile);
 };

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -21,7 +21,7 @@
 #include "UIState/MainMenu.h"
 #include "UIState/UIState.h"
 
-const char TANK_CONTROLLER_VERSION[] = "22.07.2";
+const char TANK_CONTROLLER_VERSION[] = "22.08.1";
 
 // ------------ Class Methods ------------
 /**

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -248,7 +248,6 @@ unittest(rootDir) {
   server->loop();
   server->loop();
   server->loop();
-  server->loop();
   deque<uint8_t>* pBuffer = client.writeBuffer();
   assertTrue(pBuffer->size() == 49);
   String response;
@@ -256,7 +255,15 @@ unittest(rootDir) {
     response.concat(pBuffer->front());
     pBuffer->pop_front();
   }
-  const char expectedResponse[] = "Root directory not supported by CI framework.\r\n\r\n";
+  const char expectedResponse[] =
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: text/plain;charset=UTF-8\r\n"
+      "Content-Encoding: identity\r\n"
+      "Content-Language: en-US\r\n"
+      "Access-Control-Allow-Origin: *\r\n"
+      "Content-Length: 49\r\n"
+      "\r\n"
+      "Root directory not supported by CI framework.\r\n\r\n";
   assertEqual(expectedResponse, response);
   assertEqual(FINISHED, server->getState());
   server->loop();  // Process finished state

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -187,7 +187,7 @@ unittest(current) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 1m 1s\","
-      "\"Version\":\"22.07.2\"}\r\n";
+      "\"Version\":\"22.08.1\"}\r\n";
   assertEqual(expectedResponse, response);
   assertEqual(FINISHED, server->getState());
   server->loop();  // Process finished state

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -255,7 +255,7 @@ unittest(rootDir) {
   server->loop();
   assertEqual(6, 6);
   deque<uint8_t>* pBuffer = client.writeBuffer();
-  assertEqual(pBuffer->size(), 178);
+  assertEqual(164, pBuffer->size());
   String response;
   while (!pBuffer->empty()) {
     response.concat(pBuffer->front());
@@ -274,7 +274,8 @@ unittest(rootDir) {
   server->loop();
   assertEqual(7, 7);
   pBuffer = client.writeBuffer();
-  assertEqual(pBuffer->size(), 49);
+  assertEqual(49, pBuffer->size());
+  response.clear();
   while (!pBuffer->empty()) {
     response.concat(pBuffer->front());
     pBuffer->pop_front();

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -230,15 +230,12 @@ unittest(badRequest) {
 }
 
 unittest(rootDir) {
-  assertEqual(1, 1);
   TankController* tc = TankController::instance();
   EthernetServer_TC* server = EthernetServer_TC::instance();
   EthernetClient_CI client;
   server->setHasClientCalling(true);
   delay(1);
-  assertEqual(2, 2);
   server->loop();
-  assertEqual(3, 3);
   client = server->getClient();
   const char request[] =
       "GET /api/1/rootdir HTTP/1.1\r\n"
@@ -248,12 +245,9 @@ unittest(rootDir) {
       "Accept-Language: en-US\r\n"
       "\r\n";
   client.pushToReadBuffer(request);
-  assertEqual(4, 4);
   server->loop();
-  assertEqual(5, 5);
   assertEqual(LISTING_FILES, server->getState());
   server->loop();
-  assertEqual(6, 6);
   deque<uint8_t>* pBuffer = client.writeBuffer();
   assertEqual(164, pBuffer->size());
   String response;
@@ -272,7 +266,6 @@ unittest(rootDir) {
   assertEqual(expectedResponse, response);
   assertEqual(LISTING_FILES, server->getState());
   server->loop();
-  assertEqual(7, 7);
   pBuffer = client.writeBuffer();
   assertEqual(49, pBuffer->size());
   response.clear();
@@ -284,7 +277,6 @@ unittest(rootDir) {
   assertEqual(nextExpectedResponse, response);
   assertEqual(FINISHED, server->getState());
   server->loop();  // Process finished state
-  assertEqual(8, 8);
   assertEqual(NOT_CONNECTED, server->getState());
   client.stop();
   server->loop();

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -279,8 +279,8 @@ unittest(rootDir) {
     response.concat(pBuffer->front());
     pBuffer->pop_front();
   }
-  const char expectedResponse[] = "Root directory not supported by CI framework.\r\n\r\n";
-  assertEqual(expectedResponse, response);
+  const char nextExpectedResponse[] = "Root directory not supported by CI framework.\r\n\r\n";
+  assertEqual(nextExpectedResponse, response);
   assertEqual(FINISHED, server->getState());
   server->loop();  // Process finished state
   assertEqual(8, 8);

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -246,6 +246,9 @@ unittest(rootDir) {
       "\r\n";
   client.pushToReadBuffer(request);
   server->loop();
+  server->loop();
+  server->loop();
+  server->loop();
   deque<uint8_t>* pBuffer = client.writeBuffer();
   assertTrue(pBuffer->size() == 49);
   String response;

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -230,12 +230,15 @@ unittest(badRequest) {
 }
 
 unittest(rootDir) {
+  assertEqual(1, 1);
   TankController* tc = TankController::instance();
   EthernetServer_TC* server = EthernetServer_TC::instance();
   EthernetClient_CI client;
   server->setHasClientCalling(true);
   delay(1);
+  assertEqual(2, 2);
   server->loop();
+  assertEqual(3, 3);
   client = server->getClient();
   const char request[] =
       "GET /api/1/rootdir HTTP/1.1\r\n"
@@ -245,11 +248,14 @@ unittest(rootDir) {
       "Accept-Language: en-US\r\n"
       "\r\n";
   client.pushToReadBuffer(request);
+  assertEqual(4, 4);
   server->loop();
+  assertEqual(5, 5);
+  assertEqual(LISTING_FILES, server->getState());
   server->loop();
-  server->loop();
+  assertEqual(6, 6);
   deque<uint8_t>* pBuffer = client.writeBuffer();
-  assertTrue(pBuffer->size() == 49);
+  assertEqual(pBuffer->size(), 178);
   String response;
   while (!pBuffer->empty()) {
     response.concat(pBuffer->front());
@@ -262,11 +268,22 @@ unittest(rootDir) {
       "Content-Language: en-US\r\n"
       "Access-Control-Allow-Origin: *\r\n"
       "Content-Length: 49\r\n"
-      "\r\n"
-      "Root directory not supported by CI framework.\r\n\r\n";
+      "\r\n";
+  assertEqual(expectedResponse, response);
+  assertEqual(LISTING_FILES, server->getState());
+  server->loop();
+  assertEqual(7, 7);
+  pBuffer = client.writeBuffer();
+  assertEqual(pBuffer->size(), 49);
+  while (!pBuffer->empty()) {
+    response.concat(pBuffer->front());
+    pBuffer->pop_front();
+  }
+  const char expectedResponse[] = "Root directory not supported by CI framework.\r\n\r\n";
   assertEqual(expectedResponse, response);
   assertEqual(FINISHED, server->getState());
   server->loop();  // Process finished state
+  assertEqual(8, 8);
   assertEqual(NOT_CONNECTED, server->getState());
   client.stop();
   server->loop();

--- a/test/JSONBuilderTest.cpp
+++ b/test/JSONBuilderTest.cpp
@@ -30,7 +30,7 @@ unittest(current) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 0m 1s\","
-      "\"Version\":\"22.07.2\"}";
+      "\"Version\":\"22.08.1\"}";
   assertEqual(expected, text);
 }
 

--- a/test/LiquidCrystalTest.cpp
+++ b/test/LiquidCrystalTest.cpp
@@ -21,7 +21,7 @@ unittest(loop) {
   assertEqual("Tank Controller ", lines.at(0));
   assertEqual(
       "v"
-      "22.07.2 loading",  // this allows a word-search to find the number
+      "22.08.1 loading",  // this allows a word-search to find the number
       lines.at(1));
 }
 

--- a/test/SeeVersionTest.cpp
+++ b/test/SeeVersionTest.cpp
@@ -17,7 +17,7 @@ unittest(testOutput) {
   // Test the output
   tc->loop();
   assertEqual("Software Version", display->getLines().at(0));
-  assertEqual("22.07.2         ", display->getLines().at(1));
+  assertEqual("22.08.1         ", display->getLines().at(1));
   // Return to mainMenu
   Keypad_TC::instance()->_getPuppet()->push_back('D');
   tc->loop();


### PR DESCRIPTION
This fixes some issues with HTTP headers for file transfers and for rootdir(). For the rootdir() HTTP header, the size of the body is calculated in advance by counting the number of files in the root directory on the SD card.