### PR TITLE
Ethernet: More HTTP response codes

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TankController
-version=22.7.2
+version=22.8.1
 author=Kirt Onthank <Kirt.Onthank@wallawalla.edu>, Preston Carman <prestonc@apache.org>, James Foster <github@jgfoster.net>
 maintainer=James Foster <github@jgfoster.net>
 sentence=Software for the Arduino that controls pH and temperature in the Open-Acidification project.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TankController
-version=22.8.1
+version=22.8.2
 author=Kirt Onthank <Kirt.Onthank@wallawalla.edu>, Preston Carman <prestonc@apache.org>, James Foster <github@jgfoster.net>
 maintainer=James Foster <github@jgfoster.net>
 sentence=Software for the Arduino that controls pH and temperature in the Open-Acidification project.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TankController
-version=22.4.1
+version=22.7.2
 author=Kirt Onthank <Kirt.Onthank@wallawalla.edu>, Preston Carman <prestonc@apache.org>, James Foster <github@jgfoster.net>
 maintainer=James Foster <github@jgfoster.net>
 sentence=Software for the Arduino that controls pH and temperature in the Open-Acidification project.

--- a/size.txt
+++ b/size.txt
@@ -1,1 +1,1 @@
-Global variables use 2330 bytes (28%) of dynamic memory, leaving 5836 bytes for local variables. Maximum is 8192 bytes.
+Global variables use 2362 bytes (28%) of dynamic memory, leaving 5836 bytes for local variables. Maximum is 8192 bytes.

--- a/size.txt
+++ b/size.txt
@@ -1,1 +1,1 @@
-Global variables use 2362 bytes (28%) of dynamic memory, leaving 5830 bytes for local variables. Maximum is 8192 bytes.
+Global variables use 2356 bytes (28%) of dynamic memory, leaving 5836 bytes for local variables. Maximum is 8192 bytes.

--- a/size.txt
+++ b/size.txt
@@ -1,1 +1,1 @@
-Global variables use 2356 bytes (28%) of dynamic memory, leaving 5836 bytes for local variables. Maximum is 8192 bytes.
+Global variables use 2362 bytes (28%) of dynamic memory, leaving 5836 bytes for local variables. Maximum is 8192 bytes.

--- a/size.txt
+++ b/size.txt
@@ -1,1 +1,1 @@
-Global variables use 2362 bytes (28%) of dynamic memory, leaving 5836 bytes for local variables. Maximum is 8192 bytes.
+Global variables use 2362 bytes (28%) of dynamic memory, leaving 5830 bytes for local variables. Maximum is 8192 bytes.

--- a/size.txt
+++ b/size.txt
@@ -1,1 +1,1 @@
-Global variables use 2362 bytes (28%) of dynamic memory, leaving 5836 bytes for local variables. Maximum is 8192 bytes.
+Global variables use 2330 bytes (28%) of dynamic memory, leaving 5836 bytes for local variables. Maximum is 8192 bytes.

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -457,9 +457,9 @@ void EthernetServer_TC::sendResponse(int code) {
   static const char response_501[] PROGMEM =
       "HTTP/1.1 501 Not Implemented\r\n"
       "\r\n";
-  static const char *const response_table[] PROGMEM = {response_303, response_400, response_404, response_405,
+  static const char *const response_table[] = {response_303, response_400, response_404, response_405,
                                                        response_408, response_501, response_500};
-  char buffer[sizeof(response_303)];
+  char buffer[sizeof(response_303) + 1];
   switch (code) {
     case HTTP_REDIRECT:
       strncpy_P(buffer, (char *)pgm_read_word(&(response_table[0])), sizeof(buffer));

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -457,9 +457,9 @@ void EthernetServer_TC::sendResponse(int code) {
   static const char response_501[] PROGMEM =
       "HTTP/1.1 501 Not Implemented\r\n"
       "\r\n";
-  static const char *const response_table[] = {response_303, response_400, response_404, response_405,
+  static const char *const response_table[] PROGMEM = {response_303, response_400, response_404, response_405,
                                                        response_408, response_501, response_500};
-  char buffer[sizeof(response_303) + 1];
+  char buffer[sizeof(response_303)];
   switch (code) {
     case HTTP_REDIRECT:
       strncpy_P(buffer, (char *)pgm_read_word(&(response_table[0])), sizeof(buffer));

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -235,6 +235,11 @@ void EthernetServer_TC::sendHeadersForRootdir(int fileCount) {
 #endif
 }
 
+void EthernetServer_TC::sdError() {
+  sendErrorHeaders();
+  state = FINISHED;
+}
+
 // Tests speed for reading a file from the SD Card
 // Empirical results show about 1 ms per 512 B
 void EthernetServer_TC::testReadSpeed() {
@@ -456,6 +461,14 @@ void EthernetServer_TC::sendTimeoutHeaders() {
       "HTTP/1.1 408 Request Timeout\r\n"
       "Connection: close\r\n"
       "\r\n";
+  char buffer[sizeof(response)];
+  strncpy_P(buffer, (PGM_P)response, sizeof(buffer));
+  client.write(buffer);
+}
+
+void EthernetServer_TC::sendErrorHeaders() {
+  static const char response[] PROGMEM =
+      "HTTP/1.1 500 Internal Server Error\r\n\r\n"
   char buffer[sizeof(response)];
   strncpy_P(buffer, (PGM_P)response, sizeof(buffer));
   client.write(buffer);

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -445,7 +445,7 @@ void EthernetServer_TC::sendResponse(int code) {
       "\r\n";
   static const char response_405[] PROGMEM =
       "HTTP/1.1 405 Method Not Allowed\r\n"
-      "Allow: GET, POST, HEAD\r\n"
+      "Allow: GET, POST\r\n"
       "\r\n";
   static const char response_408[] PROGMEM =
       "HTTP/1.1 408 Request Timeout\r\n"

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -69,7 +69,7 @@ void EthernetServer_TC::get() {
     fileSetup();
   } else {
     serial(F("get \"%s\" not recognized!"), buffer + 4);
-    sendBadRequestHeaders();
+    sendNotFoundHeaders();
     state = FINISHED;
   }
 }
@@ -229,11 +229,9 @@ void EthernetServer_TC::sendHeadersForRootdir(int fileCount) {
   isDoneCountingFiles = true;
   serial(F("...%i files..."), fileCount);
   sendHeadersWithSize((uint32_t)fileCount * 24);  // 24 characters per line
-  state = LISTING_FILES;  // TODO: This is here only because sendHeadersWithSize() changes the state prematurely.
 #else
   isDoneCountingFiles = true;
   sendHeadersWithSize((uint32_t)49);
-  state = LISTING_FILES;
 #endif
 }
 
@@ -419,7 +417,6 @@ void EthernetServer_TC::sendHeadersWithSize(uint32_t size) {
   // blank line indicates end of headers
   client.write('\r');
   client.write('\n');
-  state = FINISHED;  // TODO: Why?! This is awkward when we want to send a body next.
 }
 
 // 303 response
@@ -439,6 +436,15 @@ void EthernetServer_TC::sendRedirectHeaders() {
 void EthernetServer_TC::sendBadRequestHeaders() {
   char buffer[30];
   static const char response[] PROGMEM = "HTTP/1.1 400 Bad Request\r\n\r\n";
+  strncpy_P(buffer, (PGM_P)response, sizeof(buffer));
+  client.write(buffer);
+  state = FINISHED;
+}
+
+// 404 response
+void EthernetServer_TC::sendNotFoundHeaders() {
+  char buffer[30];
+  static const char response[] PROGMEM = "HTTP/1.1 404 Not Found\r\n\r\n";
   strncpy_P(buffer, (PGM_P)response, sizeof(buffer));
   client.write(buffer);
   state = FINISHED;

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -88,7 +88,6 @@ void EthernetServer_TC::post() {
   } else {
     serial(F("post \"%s\" not recognized!"), buffer + 6);
     sendResponse(HTTP_BAD_REQUEST);
-    ;
     state = FINISHED;
   }
 }

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -457,30 +457,28 @@ void EthernetServer_TC::sendResponse(int code) {
   static const char response_501[] PROGMEM =
       "HTTP/1.1 501 Not Implemented\r\n"
       "\r\n";
-  static const char *const response_table[] PROGMEM = {response_303, response_400, response_404, response_405,
-                                                       response_408, response_501, response_500};
   char buffer[sizeof(response_303)];
   switch (code) {
     case HTTP_REDIRECT:
-      strncpy_P(buffer, (char *)pgm_read_word(&(response_table[0])), sizeof(buffer));
+      strncpy_P(buffer, (PGM_P)response_303, sizeof(buffer));
       break;
     case HTTP_BAD_REQUEST:
-      strncpy_P(buffer, (char *)pgm_read_word(&(response_table[1])), sizeof(buffer));
+      strncpy_P(buffer, (PGM_P)response_400, sizeof(buffer));
       break;
     case HTTP_NOT_FOUND:
-      strncpy_P(buffer, (char *)pgm_read_word(&(response_table[2])), sizeof(buffer));
+      strncpy_P(buffer, (PGM_P)response_404, sizeof(buffer));
       break;
     case HTTP_NOT_PERMITTED:
-      strncpy_P(buffer, (char *)pgm_read_word(&(response_table[3])), sizeof(buffer));
+      strncpy_P(buffer, (PGM_P)response_405, sizeof(buffer));
       break;
     case HTTP_TIMEOUT:
-      strncpy_P(buffer, (char *)pgm_read_word(&(response_table[4])), sizeof(buffer));
+      strncpy_P(buffer, (PGM_P)response_408, sizeof(buffer));
       break;
     case HTTP_NOT_IMPLEMENTED:
-      strncpy_P(buffer, (char *)pgm_read_word(&(response_table[5])), sizeof(buffer));
+      strncpy_P(buffer, (PGM_P)response_501, sizeof(buffer));
       break;
     default:
-      strncpy_P(buffer, (char *)pgm_read_word(&(response_table[6])), sizeof(buffer));
+      strncpy_P(buffer, (PGM_P)response_500, sizeof(buffer));
   };
   client.write(buffer);
 }

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -192,7 +192,10 @@ void countFilesCallback(int fileCount) {
 void EthernetServer_TC::rootdirSetup() {
   if (state == COUNTING_FILES) {
 #ifndef MOCK_PINS_COUNT
-    SD_TC::instance()->countFiles(countFilesCallback);
+    if (!SD_TC::instance()->countFiles(countFilesCallback)) {
+      sendResponse(HTTP_ERROR);
+      state = FINISHED;
+    };
 #else
     countFilesCallback(0);
 #endif
@@ -207,7 +210,10 @@ void EthernetServer_TC::rootdirSetup() {
 void EthernetServer_TC::rootdir() {
   // Call function on SD Card
   // Provide callback to call when writing to the client buffer
-  SD_TC::instance()->listRootToBuffer(writeToClientBufferCallback);
+  if (!SD_TC::instance()->listRootToBuffer(writeToClientBufferCallback)) {
+    sendResponse(HTTP_ERROR);
+    state = FINISHED;
+  };
 }
 
 // Write to the client buffer
@@ -232,11 +238,6 @@ void EthernetServer_TC::sendHeadersForRootdir(int fileCount) {
   sendHeadersWithSize((uint32_t)49);
   state = LISTING_FILES;
 #endif
-}
-
-void EthernetServer_TC::sdError() {
-  sendResponse(HTTP_ERROR);
-  state = FINISHED;
 }
 
 // Tests speed for reading a file from the SD Card

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -49,7 +49,6 @@ public:
   void loop();
   void writeToClientBuffer(char*, bool);
   void sendHeadersForRootdir(int);
-  void sdError();
 
 private:
   // class variables

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -33,6 +33,7 @@ public:
   void loop();
   void writeToClientBuffer(char*, bool);
   void sendHeadersForRootdir(int);
+  void sdError();
 
 private:
   // class variables
@@ -57,6 +58,7 @@ private:
   void sendBadRequestHeaders();
   void sendNotFoundHeaders();
   void sendTimeoutHeaders();
+  void sendErrorHeaders();
   int weekday(int year, int month, int day);
   // instance methods: HTTP
   void get();

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -55,6 +55,7 @@ private:
   void sendHeadersWithSize(uint32_t size);
   void sendRedirectHeaders();
   void sendBadRequestHeaders();
+  void sendNotFoundHeaders();
   int weekday(int year, int month, int day);
   // instance methods: HTTP
   void get();

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -56,6 +56,7 @@ private:
   void sendRedirectHeaders();
   void sendBadRequestHeaders();
   void sendNotFoundHeaders();
+  void sendTimeoutHeaders();
   int weekday(int year, int month, int day);
   // instance methods: HTTP
   void get();

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -1,14 +1,5 @@
 #pragma once
 
-#define TIMEOUT 5000
-#define HTTP_REDIRECT 303
-#define HTTP_BAD_REQUEST 400
-#define HTTP_NOT_FOUND 404
-#define HTTP_NOT_PERMITTED 405
-#define HTTP_TIMEOUT 408
-#define HTTP_ERROR 500
-#define HTTP_NOT_IMPLEMENTED 501
-
 #include <Arduino.h>
 
 #include "SD_TC.h"
@@ -17,6 +8,15 @@
 #else
 #include <Ethernet.h>
 #endif
+
+#define TIMEOUT 5000
+#define HTTP_REDIRECT 303
+#define HTTP_BAD_REQUEST 400
+#define HTTP_NOT_FOUND 404
+#define HTTP_NOT_PERMITTED 405
+#define HTTP_TIMEOUT 408
+#define HTTP_ERROR 500
+#define HTTP_NOT_IMPLEMENTED 501
 
 enum serverState_t {
   NOT_CONNECTED,

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -9,7 +9,10 @@
 #include <Ethernet.h>
 #endif
 
-enum serverState_t { NOT_CONNECTED, READ_REQUEST, GET_REQUEST, POST_REQUEST, LISTING_FILES, IN_TRANSFER, FINISHED };
+enum serverState_t { 
+  NOT_CONNECTED, READ_REQUEST, 
+  GET_REQUEST, POST_REQUEST, OPTIONS_REQUEST, 
+  LISTING_FILES, IN_TRANSFER, FINISHED };
 
 /**
  * EthernetServer_TC provides wrapper for web server for TankController
@@ -56,6 +59,7 @@ private:
   // instance methods: HTTP
   void get();
   void post();
+  void options();
   void echo();
   void apiHandler();
   void current();

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#define TIMEOUT 5000
+#define HTTP_REDIRECT 303
+#define HTTP_BAD_REQUEST 400
+#define HTTP_NOT_FOUND 404
+#define HTTP_NOT_PERMITTED 405
+#define HTTP_TIMEOUT 408
+#define HTTP_ERROR 500
+#define HTTP_NOT_IMPLEMENTED 501
+
 #include <Arduino.h>
 
 #include "SD_TC.h"
@@ -54,11 +63,7 @@ private:
   EthernetServer_TC(uint16_t port);
   // instance methods: utility
   void sendHeadersWithSize(uint32_t size);
-  void sendRedirectHeaders();
-  void sendBadRequestHeaders();
-  void sendNotFoundHeaders();
-  void sendTimeoutHeaders();
-  void sendErrorHeaders();
+  void sendResponse(int);
   int weekday(int year, int month, int day);
   // instance methods: HTTP
   void get();

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -9,7 +9,7 @@
 #include <Ethernet.h>
 #endif
 
-enum serverState_t { NOT_CONNECTED, READ_REQUEST, GET_REQUEST, POST_REQUEST, IN_PROGRESS, IN_TRANSFER, FINISHED };
+enum serverState_t { NOT_CONNECTED, READ_REQUEST, GET_REQUEST, POST_REQUEST, LISTING_FILES, IN_TRANSFER, FINISHED };
 
 /**
  * EthernetServer_TC provides wrapper for web server for TankController
@@ -29,6 +29,7 @@ public:
   }
   void loop();
   void writeToClientBuffer(char*, bool);
+  void sendHeadersForRootdir(int);
 
 private:
   // class variables
@@ -43,12 +44,12 @@ private:
   unsigned long connectedAt = 0;
   File file;
   int startTime;
+  bool isDoneCountingFiles = true;  // TODO: Perhaps replace this with a new COUNTING_FILES state
 
   // instance methods: constructor
   EthernetServer_TC(uint16_t port);
   // instance methods: utility
   void sendHeadersWithSize(uint32_t size);
-  void sendFileHeadersWithSize(uint32_t size);
   void sendRedirectHeaders();
   void sendBadRequestHeaders();
   int weekday(int year, int month, int day);

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -80,6 +80,7 @@ private:
   void current();
   void display();
   void keypress();
+  void rootdirSetup();
   void rootdir();
   void testReadSpeed();
   void testWriteSpeed();

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -18,10 +18,17 @@
 #include <Ethernet.h>
 #endif
 
-enum serverState_t { 
-  NOT_CONNECTED, READ_REQUEST, 
-  GET_REQUEST, POST_REQUEST, OPTIONS_REQUEST, 
-  LISTING_FILES, IN_TRANSFER, FINISHED };
+enum serverState_t {
+  NOT_CONNECTED,
+  READ_REQUEST,
+  GET_REQUEST,
+  POST_REQUEST,
+  OPTIONS_REQUEST,
+  COUNTING_FILES,
+  LISTING_FILES,
+  IN_TRANSFER,
+  FINISHED
+};
 
 /**
  * EthernetServer_TC provides wrapper for web server for TankController
@@ -57,7 +64,6 @@ private:
   unsigned long connectedAt = 0;
   File file;
   int startTime;
-  bool isDoneCountingFiles = true;  // TODO: Perhaps replace this with a new COUNTING_FILES state
 
   // instance methods: constructor
   EthernetServer_TC(uint16_t port);

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -128,6 +128,7 @@ void SD_TC::countFiles(void (*callWhenFinished)(int)) {
     fileStack[0] = SD_TC::instance()->open(path);
     if (!fileStack[0]) {
       serial(F("SD_TC open() failed"));
+      EthernetServer_TC::instance()->sdError();
       return;
     }
     fileStack[0].rewind();
@@ -173,6 +174,7 @@ void SD_TC::listRootToBuffer(void (*callWhenFull)(char*, bool)) {
     fileStack[0] = SD_TC::instance()->open(path);
     if (!fileStack[0]) {
       serial(F("SD_TC open() failed"));
+      EthernetServer_TC::instance()->sdError();
       return;
     }
     fileStack[0].rewind();

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -1,7 +1,6 @@
 #include "Devices/SD_TC.h"
 
 #include "DateTime_TC.h"
-#include "EthernetServer_TC.h"
 #include "Serial_TC.h"
 #include "TC_util.h"
 
@@ -123,14 +122,13 @@ bool SD_TC::incrementFileCount(File* myFile, void* pFileCount) {
   return ++(*(int*)pFileCount) % 10 != 0;  // Pause after counting 10 files
 }
 
-void SD_TC::countFiles(void (*callWhenFinished)(int)) {
+bool SD_TC::countFiles(void (*callWhenFinished)(int)) {
   if (!inProgress) {
     const char path[] PROGMEM = "/";
     fileStack[0] = SD_TC::instance()->open(path);
     if (!fileStack[0]) {
       serial(F("SD_TC open() failed"));
-      EthernetServer_TC::instance()->sdError();
-      return;
+      return false;  // Function is unsuccessful
     }
     fileStack[0].rewind();
     fileStackSize = 1;
@@ -141,6 +139,7 @@ void SD_TC::countFiles(void (*callWhenFinished)(int)) {
   if (!inProgress) {
     callWhenFinished(fileCount);
   }
+  return true;
 }
 
 // Issue: This function does not visually display depth for items in subfolders
@@ -168,15 +167,14 @@ bool SD_TC::listFile(File* myFile, void* userData) {
 #endif
 }
 
-void SD_TC::listRootToBuffer(void (*callWhenFull)(char*, bool)) {
+bool SD_TC::listRootToBuffer(void (*callWhenFull)(char*, bool)) {
 #ifndef MOCK_PINS_COUNT
   if (!inProgress) {
     const char path[] PROGMEM = "/";
     fileStack[0] = SD_TC::instance()->open(path);
     if (!fileStack[0]) {
       serial(F("SD_TC open() failed"));
-      EthernetServer_TC::instance()->sdError();
-      return;
+      return false;  // Function is unsuccessful
     }
     fileStack[0].rewind();
     fileStackSize = 1;
@@ -189,11 +187,13 @@ void SD_TC::listRootToBuffer(void (*callWhenFull)(char*, bool)) {
   // Terminate the buffer
   listFileData.buffer[listFileData.linePos] = '\0';
   callWhenFull(listFileData.buffer, !inProgress);
+  return true;
 #else
   static const char notImplemented[] PROGMEM = "Root directory not supported by CI framework.\r\n";
   char buffer[sizeof(notImplemented)];
   memcpy(buffer, (PGM_P)notImplemented, sizeof(notImplemented));
   callWhenFull(buffer, true);
+  return true;
 #endif
 }
 

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -77,7 +77,11 @@ void SD_TC::appendToLog(const char* line) {
 }
 
 bool SD_TC::exists(const char* path) {
+#ifndef MOCK_PINS_COUNT
   return sd.exists(path);
+#else
+  return false;
+#endif
 }
 
 bool SD_TC::format() {

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -77,11 +77,7 @@ void SD_TC::appendToLog(const char* line) {
 }
 
 bool SD_TC::exists(const char* path) {
-#ifndef MOCK_PINS_COUNT
   return sd.exists(path);
-#else
-  return false;
-#endif
 }
 
 bool SD_TC::format() {

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -1,6 +1,7 @@
 #include "Devices/SD_TC.h"
 
 #include "DateTime_TC.h"
+#include "EthernetServer_TC.h"
 #include "Serial_TC.h"
 #include "TC_util.h"
 

--- a/src/Devices/SD_TC.h
+++ b/src/Devices/SD_TC.h
@@ -24,8 +24,8 @@ public:
   void appendToLog(const char* line);
   bool exists(const char* path);
   bool format();
-  void listRootToBuffer(void (*callWhenFull)(char*, bool));
-  void countFiles(void (*callWhenFinished)(int));
+  bool listRootToBuffer(void (*callWhenFull)(char*, bool));
+  bool countFiles(void (*callWhenFinished)(int));
   bool mkdir(const char* path);
   File open(const char* path, oflag_t oflag = 0x00);
   void printRootDirectory();

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -21,7 +21,7 @@
 #include "UIState/MainMenu.h"
 #include "UIState/UIState.h"
 
-const char TANK_CONTROLLER_VERSION[] = "22.08.1";
+const char TANK_CONTROLLER_VERSION[] = "22.08.2";
 
 // ------------ Class Methods ------------
 /**

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -21,7 +21,7 @@
 #include "UIState/MainMenu.h"
 #include "UIState/UIState.h"
 
-const char TANK_CONTROLLER_VERSION[] = "22.07.2";
+const char TANK_CONTROLLER_VERSION[] = "22.08.1";
 
 // ------------ Class Methods ------------
 /**

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -21,7 +21,7 @@
 #include "UIState/MainMenu.h"
 #include "UIState/UIState.h"
 
-const char TANK_CONTROLLER_VERSION[] = "22.07.1";
+const char TANK_CONTROLLER_VERSION[] = "22.07.2";
 
 // ------------ Class Methods ------------
 /**

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -21,7 +21,7 @@
 #include "UIState/MainMenu.h"
 #include "UIState/UIState.h"
 
-const char TANK_CONTROLLER_VERSION[] = "22.04.1";
+const char TANK_CONTROLLER_VERSION[] = "22.07.1";
 
 // ------------ Class Methods ------------
 /**

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -100,20 +100,13 @@ unittest(display) {
 unittest(keypress) {
   TankController* tc = TankController::instance();
   LiquidCrystal_TC* lcd = LiquidCrystal_TC::instance();
-  assertEqual(0,0);
   assertEqual("MainMenu", tc->stateName());
-  assertEqual(1,1);
   EthernetServer_TC* server = EthernetServer_TC::instance();
-  assertEqual(2,2);
   EthernetClient_CI client;
-  assertEqual(3,3);
   server->setHasClientCalling(true);
-  assertEqual(4,4);
   delay(1);
   server->loop();
-  assertEqual(5,5);
   client = server->getClient();
-  assertEqual(6,6);
   const char request[] =
       "POST /api/1/key?value=2 HTTP/1.1\r\n"
       "Host: localhost:80\r\n"
@@ -121,13 +114,9 @@ unittest(keypress) {
       "Accept-Encoding: identity\r\n"
       "Accept-Language: en-US\r\n"
       "\r\n";
-  assertEqual(7,7);
   client.pushToReadBuffer(request);
-  assertEqual(8,8);
   server->loop();
-  assertEqual(9,9);
   deque<uint8_t>* pBuffer = client.writeBuffer();
-  assertEqual(10,10);
   assertEqual(84, pBuffer->size());
   String response;
   while (!pBuffer->empty()) {

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -257,7 +257,7 @@ unittest(rootDir) {
       "\r\n";
   client.pushToReadBuffer(request);
   server->loop();
-  assertEqual(LISTING_FILES, server->getState());
+  assertEqual(COUNTING_FILES, server->getState());
   server->loop();
   deque<uint8_t>* pBuffer = client.writeBuffer();
   assertEqual(164, pBuffer->size());

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -282,6 +282,39 @@ unittest(rootDir) {
   server->loop();
 }
 
+unittest(fileNotFound) {
+  TankController* tc = TankController::instance();
+  EthernetServer_TC* server = EthernetServer_TC::instance();
+  EthernetClient_CI client;
+  server->setHasClientCalling(true);
+  delay(1);
+  server->loop();
+  client = server->getClient();
+  const char request[] =
+      "GET /17760704.log HTTP/1.1\r\n"
+      "Host: localhost:80\r\n"
+      "Accept: text/plain;charset=UTF-8\r\n"
+      "Accept-Encoding: identity\r\n"
+      "Accept-Language: en-US\r\n"
+      "\r\n";
+  client.pushToReadBuffer(request);
+  server->loop();
+  deque<uint8_t>* pBuffer = client.writeBuffer();
+  assertEqual(26, pBuffer->size());
+  String response;
+  while (!pBuffer->empty()) {
+    response.concat(pBuffer->front());
+    pBuffer->pop_front();
+  }
+  const char expectedResponse[] = "HTTP/1.1 404 Not Found\r\n\r\n";
+  assertEqual(expectedResponse, response);
+  assertEqual(FINISHED, server->getState());
+  server->loop();  // Process finished state
+  assertEqual(NOT_CONNECTED, server->getState());
+  client.stop();
+  server->loop();
+}
+
 unittest(timeout) {
   TankController* tc = TankController::instance();
   EthernetServer_TC* server = EthernetServer_TC::instance();

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -187,7 +187,7 @@ unittest(current) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 1m 1s\","
-      "\"Version\":\"22.07.1\"}\r\n";
+      "\"Version\":\"22.07.2\"}\r\n";
   assertEqual(expectedResponse, response);
   assertEqual(FINISHED, server->getState());
   server->loop();  // Process finished state

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -187,7 +187,7 @@ unittest(current) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 1m 1s\","
-      "\"Version\":\"22.04.1\"}\r\n";
+      "\"Version\":\"22.07.1\"}\r\n";
   assertEqual(expectedResponse, response);
   assertEqual(FINISHED, server->getState());
   server->loop();  // Process finished state

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -100,19 +100,20 @@ unittest(display) {
 unittest(keypress) {
   TankController* tc = TankController::instance();
   LiquidCrystal_TC* lcd = LiquidCrystal_TC::instance();
+  serial("keypress-0");
   assertEqual("MainMenu", tc->stateName());
-  cout << "keypress-1";
+  serial("keypress-1");
   EthernetServer_TC* server = EthernetServer_TC::instance();
-  cout << "keypress-2";
+  serial("keypress-2");
   EthernetClient_CI client;
-  cout << "keypress-3";
+  serial("keypress-3");
   server->setHasClientCalling(true);
-  cout << "keypress-4";
+  serial("keypress-4");
   delay(1);
   server->loop();
-  cout << "keypress-5";
+  serial("keypress-5");
   client = server->getClient();
-  cout << "keypress-6";
+  serial("keypress-6");
   const char request[] =
       "POST /api/1/key?value=2 HTTP/1.1\r\n"
       "Host: localhost:80\r\n"
@@ -120,13 +121,13 @@ unittest(keypress) {
       "Accept-Encoding: identity\r\n"
       "Accept-Language: en-US\r\n"
       "\r\n";
-  cout << "keypress-7";
+  serial("keypress-7");
   client.pushToReadBuffer(request);
-  cout << "keypress-8";
+  serial("keypress-8");
   server->loop();
-  cout << "keypress-9";
+  serial("keypress-9");
   deque<uint8_t>* pBuffer = client.writeBuffer();
-  cout << "keypress-10";
+  serial("keypress-10");
   assertEqual(84, pBuffer->size());
   String response;
   while (!pBuffer->empty()) {

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -100,20 +100,20 @@ unittest(display) {
 unittest(keypress) {
   TankController* tc = TankController::instance();
   LiquidCrystal_TC* lcd = LiquidCrystal_TC::instance();
-  serial("keypress-0");
+  assertEqual(0,0);
   assertEqual("MainMenu", tc->stateName());
-  serial("keypress-1");
+  assertEqual(1,1);
   EthernetServer_TC* server = EthernetServer_TC::instance();
-  serial("keypress-2");
+  assertEqual(2,2);
   EthernetClient_CI client;
-  serial("keypress-3");
+  assertEqual(3,3);
   server->setHasClientCalling(true);
-  serial("keypress-4");
+  assertEqual(4,4);
   delay(1);
   server->loop();
-  serial("keypress-5");
+  assertEqual(5,5);
   client = server->getClient();
-  serial("keypress-6");
+  assertEqual(6,6);
   const char request[] =
       "POST /api/1/key?value=2 HTTP/1.1\r\n"
       "Host: localhost:80\r\n"
@@ -121,13 +121,13 @@ unittest(keypress) {
       "Accept-Encoding: identity\r\n"
       "Accept-Language: en-US\r\n"
       "\r\n";
-  serial("keypress-7");
+  assertEqual(7,7);
   client.pushToReadBuffer(request);
-  serial("keypress-8");
+  assertEqual(8,8);
   server->loop();
-  serial("keypress-9");
+  assertEqual(9,9);
   deque<uint8_t>* pBuffer = client.writeBuffer();
-  serial("keypress-10");
+  assertEqual(10,10);
   assertEqual(84, pBuffer->size());
   String response;
   while (!pBuffer->empty()) {

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -187,7 +187,7 @@ unittest(current) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 1m 1s\","
-      "\"Version\":\"22.07.2\"}\r\n";
+      "\"Version\":\"22.08.1\"}\r\n";
   assertEqual(expectedResponse, response);
   assertEqual(FINISHED, server->getState());
   server->loop();  // Process finished state
@@ -246,15 +246,35 @@ unittest(rootDir) {
       "\r\n";
   client.pushToReadBuffer(request);
   server->loop();
+  assertEqual(LISTING_FILES, server->getState());
+  server->loop();
   deque<uint8_t>* pBuffer = client.writeBuffer();
-  assertTrue(pBuffer->size() == 49);
+  assertEqual(164, pBuffer->size());
   String response;
   while (!pBuffer->empty()) {
     response.concat(pBuffer->front());
     pBuffer->pop_front();
   }
-  const char expectedResponse[] = "Root directory not supported by CI framework.\r\n\r\n";
+  const char expectedResponse[] =
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: text/plain;charset=UTF-8\r\n"
+      "Content-Encoding: identity\r\n"
+      "Content-Language: en-US\r\n"
+      "Access-Control-Allow-Origin: *\r\n"
+      "Content-Length: 49\r\n"
+      "\r\n";
   assertEqual(expectedResponse, response);
+  assertEqual(LISTING_FILES, server->getState());
+  server->loop();
+  pBuffer = client.writeBuffer();
+  assertEqual(49, pBuffer->size());
+  response.clear();
+  while (!pBuffer->empty()) {
+    response.concat(pBuffer->front());
+    pBuffer->pop_front();
+  }
+  const char nextExpectedResponse[] = "Root directory not supported by CI framework.\r\n\r\n";
+  assertEqual(nextExpectedResponse, response);
   assertEqual(FINISHED, server->getState());
   server->loop();  // Process finished state
   assertEqual(NOT_CONNECTED, server->getState());

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -315,6 +315,39 @@ unittest(fileNotFound) {
   server->loop();
 }
 
+unittest(options) {
+  TankController* tc = TankController::instance();
+  EthernetServer_TC* server = EthernetServer_TC::instance();
+  EthernetClient_CI client;
+  server->setHasClientCalling(true);
+  delay(1);
+  server->loop();
+  client = server->getClient();
+  const char request[] =
+      "OPTIONS /index.html HTTP/1.1\r\n"
+      "Host: localhost:80\r\n"
+      "Accept: text/plain;charset=UTF-8\r\n"
+      "Accept-Encoding: identity\r\n"
+      "Accept-Language: en-US\r\n"
+      "\r\n";
+  client.pushToReadBuffer(request);
+  server->loop();
+  deque<uint8_t>* pBuffer = client.writeBuffer();
+  assertEqual(53, pBuffer->size());
+  String response;
+  while (!pBuffer->empty()) {
+    response.concat(pBuffer->front());
+    pBuffer->pop_front();
+  }
+  const char expectedResponse[] = "HTTP/1.1 405 Method Not Allowed\r\nAllow: GET, POST\r\n\r\n";
+  assertEqual(expectedResponse, response);
+  assertEqual(FINISHED, server->getState());
+  server->loop();  // Process finished state
+  assertEqual(NOT_CONNECTED, server->getState());
+  client.stop();
+  server->loop();
+}
+
 unittest(timeout) {
   TankController* tc = TankController::instance();
   EthernetServer_TC* server = EthernetServer_TC::instance();

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -187,7 +187,7 @@ unittest(current) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 1m 1s\","
-      "\"Version\":\"22.08.1\"}\r\n";
+      "\"Version\":\"22.08.2\"}\r\n";
   assertEqual(expectedResponse, response);
   assertEqual(FINISHED, server->getState());
   server->loop();  // Process finished state

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -101,6 +101,7 @@ unittest(keypress) {
   TankController* tc = TankController::instance();
   LiquidCrystal_TC* lcd = LiquidCrystal_TC::instance();
   assertEqual("MainMenu", tc->stateName());
+  cout << "keypress-1";
   EthernetServer_TC* server = EthernetServer_TC::instance();
   cout << "keypress-2";
   EthernetClient_CI client;
@@ -111,6 +112,7 @@ unittest(keypress) {
   server->loop();
   cout << "keypress-5";
   client = server->getClient();
+  cout << "keypress-6";
   const char request[] =
       "POST /api/1/key?value=2 HTTP/1.1\r\n"
       "Host: localhost:80\r\n"
@@ -118,11 +120,13 @@ unittest(keypress) {
       "Accept-Encoding: identity\r\n"
       "Accept-Language: en-US\r\n"
       "\r\n";
+  cout << "keypress-7";
   client.pushToReadBuffer(request);
   cout << "keypress-8";
   server->loop();
   cout << "keypress-9";
   deque<uint8_t>* pBuffer = client.writeBuffer();
+  cout << "keypress-10";
   assertEqual(84, pBuffer->size());
   String response;
   while (!pBuffer->empty()) {

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -292,7 +292,11 @@ unittest(timeout) {
   client = server->getClient();
   server->loop();
   assertEqual(READ_REQUEST, server->getState());
-  delay(1000);
+  delay(50);
+  server->loop();
+  delay(50);
+  server->loop();
+  delay(50);
   server->loop();
   assertEqual(READ_REQUEST, server->getState());
   delay(5000);  // Wait for timeout

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -101,12 +101,18 @@ unittest(keypress) {
   TankController* tc = TankController::instance();
   LiquidCrystal_TC* lcd = LiquidCrystal_TC::instance();
   assertEqual("MainMenu", tc->stateName());
+  cout << "keypress-1";
   EthernetServer_TC* server = EthernetServer_TC::instance();
+  cout << "keypress-2";
   EthernetClient_CI client;
+  cout << "keypress-3";
   server->setHasClientCalling(true);
+  cout << "keypress-4";
   delay(1);
   server->loop();
+  cout << "keypress-5";
   client = server->getClient();
+  cout << "keypress-6";
   const char request[] =
       "POST /api/1/key?value=2 HTTP/1.1\r\n"
       "Host: localhost:80\r\n"
@@ -114,9 +120,13 @@ unittest(keypress) {
       "Accept-Encoding: identity\r\n"
       "Accept-Language: en-US\r\n"
       "\r\n";
+  cout << "keypress-7";
   client.pushToReadBuffer(request);
+  cout << "keypress-8";
   server->loop();
+  cout << "keypress-9";
   deque<uint8_t>* pBuffer = client.writeBuffer();
+  cout << "keypress-10";
   assertEqual(84, pBuffer->size());
   String response;
   while (!pBuffer->empty()) {

--- a/test/JSONBuilderTest.cpp
+++ b/test/JSONBuilderTest.cpp
@@ -30,7 +30,7 @@ unittest(current) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 0m 1s\","
-      "\"Version\":\"22.07.2\"}";
+      "\"Version\":\"22.08.1\"}";
   assertEqual(expected, text);
 }
 

--- a/test/JSONBuilderTest.cpp
+++ b/test/JSONBuilderTest.cpp
@@ -30,7 +30,7 @@ unittest(current) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 0m 1s\","
-      "\"Version\":\"22.08.1\"}";
+      "\"Version\":\"22.08.2\"}";
   assertEqual(expected, text);
 }
 

--- a/test/JSONBuilderTest.cpp
+++ b/test/JSONBuilderTest.cpp
@@ -30,7 +30,7 @@ unittest(current) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 0m 1s\","
-      "\"Version\":\"22.07.1\"}";
+      "\"Version\":\"22.07.2\"}";
   assertEqual(expected, text);
 }
 

--- a/test/JSONBuilderTest.cpp
+++ b/test/JSONBuilderTest.cpp
@@ -30,7 +30,7 @@ unittest(current) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 0m 1s\","
-      "\"Version\":\"22.04.1\"}";
+      "\"Version\":\"22.07.1\"}";
   assertEqual(expected, text);
 }
 

--- a/test/LiquidCrystalTest.cpp
+++ b/test/LiquidCrystalTest.cpp
@@ -21,7 +21,7 @@ unittest(loop) {
   assertEqual("Tank Controller ", lines.at(0));
   assertEqual(
       "v"
-      "22.08.1 loading",  // this allows a word-search to find the number
+      "22.08.2 loading",  // this allows a word-search to find the number
       lines.at(1));
 }
 

--- a/test/LiquidCrystalTest.cpp
+++ b/test/LiquidCrystalTest.cpp
@@ -21,7 +21,7 @@ unittest(loop) {
   assertEqual("Tank Controller ", lines.at(0));
   assertEqual(
       "v"
-      "22.07.1 loading",  // this allows a word-search to find the number
+      "22.07.2 loading",  // this allows a word-search to find the number
       lines.at(1));
 }
 

--- a/test/LiquidCrystalTest.cpp
+++ b/test/LiquidCrystalTest.cpp
@@ -21,7 +21,7 @@ unittest(loop) {
   assertEqual("Tank Controller ", lines.at(0));
   assertEqual(
       "v"
-      "22.04.1 loading",  // this allows a word-search to find the number
+      "22.07.1 loading",  // this allows a word-search to find the number
       lines.at(1));
 }
 

--- a/test/LiquidCrystalTest.cpp
+++ b/test/LiquidCrystalTest.cpp
@@ -21,7 +21,7 @@ unittest(loop) {
   assertEqual("Tank Controller ", lines.at(0));
   assertEqual(
       "v"
-      "22.07.2 loading",  // this allows a word-search to find the number
+      "22.08.1 loading",  // this allows a word-search to find the number
       lines.at(1));
 }
 

--- a/test/SeeVersionTest.cpp
+++ b/test/SeeVersionTest.cpp
@@ -17,7 +17,7 @@ unittest(testOutput) {
   // Test the output
   tc->loop();
   assertEqual("Software Version", display->getLines().at(0));
-  assertEqual("22.07.1         ", display->getLines().at(1));
+  assertEqual("22.07.2         ", display->getLines().at(1));
   // Return to mainMenu
   Keypad_TC::instance()->_getPuppet()->push_back('D');
   tc->loop();

--- a/test/SeeVersionTest.cpp
+++ b/test/SeeVersionTest.cpp
@@ -17,7 +17,7 @@ unittest(testOutput) {
   // Test the output
   tc->loop();
   assertEqual("Software Version", display->getLines().at(0));
-  assertEqual("22.08.1         ", display->getLines().at(1));
+  assertEqual("22.08.2         ", display->getLines().at(1));
   // Return to mainMenu
   Keypad_TC::instance()->_getPuppet()->push_back('D');
   tc->loop();

--- a/test/SeeVersionTest.cpp
+++ b/test/SeeVersionTest.cpp
@@ -17,7 +17,7 @@ unittest(testOutput) {
   // Test the output
   tc->loop();
   assertEqual("Software Version", display->getLines().at(0));
-  assertEqual("22.04.1         ", display->getLines().at(1));
+  assertEqual("22.07.1         ", display->getLines().at(1));
   // Return to mainMenu
   Keypad_TC::instance()->_getPuppet()->push_back('D');
   tc->loop();

--- a/test/SeeVersionTest.cpp
+++ b/test/SeeVersionTest.cpp
@@ -17,7 +17,7 @@ unittest(testOutput) {
   // Test the output
   tc->loop();
   assertEqual("Software Version", display->getLines().at(0));
-  assertEqual("22.07.2         ", display->getLines().at(1));
+  assertEqual("22.08.1         ", display->getLines().at(1));
   // Return to mainMenu
   Keypad_TC::instance()->_getPuppet()->push_back('D');
   tc->loop();


### PR DESCRIPTION
- New HTTP response codes: 404 (not found), 405 (not permitted), 408 (timeout), 500 (internal server error)
- Consolidate HTTP response functions for codes other than 200.
- New connections with no request remain open for 5 seconds before timing out with 408 response. Includes a test.
- If the root directory on the SD card fails to open during rootdir(), a 500 response is sent to the client and the state is reset.
- If EthernetServer_TC's loop() encounters an unknown state (due to programmer error), a 500 response is sent to the client and the state is reset.
- New state COUNTING_FILES replaces boolean isDoneCountingFiles.
- New test: GET request that receives 404 Not Found response
- New test: OPTIONS request that receives 405 Method Not Allowed response
- New test: FOO request that receives 501 Not Implemented response