### PR TITLE
Refactor `strscpy_P` to use `__FlashStringHelper *`

### DIFF
--- a/extras/scripts/build.sh
+++ b/extras/scripts/build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --skip-unittests 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 ); result=$?
+bundle exec arduino_ci.rb --min-free-space=5930 --skip-unittests 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 ); result=$?
 exit "$result"

--- a/extras/scripts/build.sh
+++ b/extras/scripts/build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5930 --skip-unittests 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 ); result=$?
+bundle exec arduino_ci.rb --min-free-space=5898 --skip-unittests 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 ); result=$?
 exit "$result"

--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5930 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
+bundle exec arduino_ci.rb --min-free-space=5898 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
 result="${PIPESTATUS[0]}"
 exit "$result"

--- a/src/Devices/DateTime_TC.cpp
+++ b/src/Devices/DateTime_TC.cpp
@@ -48,14 +48,14 @@ DateTime_TC::DateTime_TC(uint16_t year, uint8_t month, uint8_t day, uint8_t hour
  */
 char buffer[20];
 char *DateTime_TC::as16CharacterString() {
-  strscpy_P(buffer, (PGM_P)F("YYYY-MM-DD hh:mm"), sizeof(buffer));
+  strscpy_P(buffer, F("YYYY-MM-DD hh:mm"), sizeof(buffer));
   this->toString(buffer);
   return buffer;
 }
 
 void DateTime_TC::printToSerial() {
   char buffer[20];
-  strscpy_P(buffer, (PGM_P)F("YYYY-MM-DD hh:mm:ss"), sizeof(buffer));
+  strscpy_P(buffer, F("YYYY-MM-DD hh:mm:ss"), sizeof(buffer));
   DateTime_TC now = DateTime_TC::now();
   now.toString(buffer);
   serial(F("%s"), buffer);

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -31,10 +31,10 @@ EthernetServer_TC::EthernetServer_TC(uint16_t port) : EthernetServer(port) {
   begin();
   IPAddress IP = Ethernet_TC::instance()->getIP();
   serial(F("Ethernet Server is listening on %i.%i.%i.%i:80"), IP[0], IP[1], IP[2], IP[3]);
-  static const char boundary_P[] PROGMEM = "boundary";
+  const __FlashStringHelper *boundary_P = F("boundary");
   // TODO: A long string of apparently random characters should be used as the boundary instead,
   // because they would be less likely to be part of the message
-  strscpy_P(boundary, (PGM_P)boundary_P, sizeof(boundary));
+  strscpy_P(boundary, boundary_P, sizeof(boundary));
 }
 
 // echo() - Proof of concept for the EthernetServer
@@ -244,9 +244,9 @@ void EthernetServer_TC::sendHeadersForRootdir(int fileCount) {
 // Empirical results show about 1 ms per 512 B
 void EthernetServer_TC::testReadSpeed() {
   wdt_disable();
-  static const char path[] PROGMEM = "tstRdSpd.txt";
+  const __FlashStringHelper *path = F("tstRdSpd.txt");
   char temp[sizeof(path)];
-  strscpy_P(temp, (PGM_P)path, sizeof(temp));
+  strscpy_P(temp, path, sizeof(temp));
   // Create the file and write garbage
   file = SD_TC::instance()->open(temp, O_RDWR | O_CREAT | O_AT_END);
   memset(buffer, ' ', sizeof(buffer));
@@ -408,21 +408,22 @@ void EthernetServer_TC::loop() {
 
 // 200 response with a content size
 void EthernetServer_TC::sendHeadersWithSize(uint32_t size) {
-  static const char response[] PROGMEM =
-      "HTTP/1.1 200 OK\r\n"
-      "Content-Type: text/plain;charset=UTF-8\r\n"
-      "Content-Encoding: identity\r\n"
-      "Content-Language: en-US\r\n"
-      "Access-Control-Allow-Origin: *\r\n";
+  const __FlashStringHelper *response =
+      F("HTTP/1.1 200 OK\r\n"
+        "Content-Type: text/plain;charset=UTF-8\r\n"
+        "Content-Encoding: identity\r\n"
+        "Content-Language: en-US\r\n"
+        "Access-Control-Allow-Origin: *\r\n");
   char buffer[sizeof(response)];
-  strscpy_P(buffer, (PGM_P)response, sizeof(buffer));
+  strscpy_P(buffer, response, sizeof(buffer));
   client.write(buffer);
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("Content-Length: %lu\r\n"), (unsigned long)size);
   client.write(buffer);
 
   // TODO: add "Date: " header
-  // const __FlashStringHelper* weekdays[] = {F("Sun"), F("Mon"), F("Tue"), F("Wed"), F("Thu"), F("Fri"), F("Sat")};
-  // const __FlashStringHelper* months[] = {F("Jan"), F("Feb"), F("Mar"), F("Apr"), F("May"), F("Jun"),
+  // const PROGMEM __FlashStringHelper* weekdays[] = {F("Sun"), F("Mon"), F("Tue"), F("Wed"), F("Thu"), F("Fri"),
+  // F("Sat")}; const PROGMEM __FlashStringHelper* months[] = {F("Jan"), F("Feb"), F("Mar"), F("Apr"), F("May"),
+  // F("Jun"),
   //                                        F("Jul"), F("Aug"), F("Sep"), F("Oct"), F("Nov"), F("Dec")};
   // DateTime_TC now = DateTime_TC::now();
   // int weekday = weekday(now.getYear(), now.getMonth(), now.getDay());
@@ -434,53 +435,53 @@ void EthernetServer_TC::sendHeadersWithSize(uint32_t size) {
 }
 
 void EthernetServer_TC::sendResponse(int code) {
-  static const char response_303[] PROGMEM =
-      "HTTP/1.1 303 See Other\r\n"
-      "Location: /api/1/display\r\n"
-      "Access-Control-Allow-Origin: *\r\n"
-      "\r\n";
-  static const char response_400[] PROGMEM =
-      "HTTP/1.1 400 Bad Request\r\n"
-      "\r\n";
-  static const char response_404[] PROGMEM =
-      "HTTP/1.1 404 Not Found\r\n"
-      "\r\n";
-  static const char response_405[] PROGMEM =
-      "HTTP/1.1 405 Method Not Allowed\r\n"
-      "Allow: GET, POST\r\n"
-      "\r\n";
-  static const char response_408[] PROGMEM =
-      "HTTP/1.1 408 Request Timeout\r\n"
-      "Connection: close\r\n"
-      "\r\n";
-  static const char response_500[] PROGMEM =
-      "HTTP/1.1 500 Internal Server Error\r\n"
-      "\r\n";
-  static const char response_501[] PROGMEM =
-      "HTTP/1.1 501 Not Implemented\r\n"
-      "\r\n";
+  const __FlashStringHelper *response_303 =
+      F("HTTP/1.1 303 See Other\r\n"
+        "Location: /api/1/display\r\n"
+        "Access-Control-Allow-Origin: *\r\n"
+        "\r\n");
+  const __FlashStringHelper *response_400 =
+      F("HTTP/1.1 400 Bad Request\r\n"
+        "\r\n");
+  const __FlashStringHelper *response_404 =
+      F("HTTP/1.1 404 Not Found\r\n"
+        "\r\n");
+  const __FlashStringHelper *response_405 =
+      F("HTTP/1.1 405 Method Not Allowed\r\n"
+        "Allow: GET, POST\r\n"
+        "\r\n");
+  const __FlashStringHelper *response_408 =
+      F("HTTP/1.1 408 Request Timeout\r\n"
+        "Connection: close\r\n"
+        "\r\n");
+  const __FlashStringHelper *response_500 =
+      F("HTTP/1.1 500 Internal Server Error\r\n"
+        "\r\n");
+  const __FlashStringHelper *response_501 =
+      F("HTTP/1.1 501 Not Implemented\r\n"
+        "\r\n");
   char buffer[sizeof(response_303)];  // Use longest of above responses
   switch (code) {
     case HTTP_REDIRECT:
-      strscpy_P(buffer, (PGM_P)response_303, sizeof(buffer));
+      strscpy_P(buffer, response_303, sizeof(buffer));
       break;
     case HTTP_BAD_REQUEST:
-      strscpy_P(buffer, (PGM_P)response_400, sizeof(buffer));
+      strscpy_P(buffer, response_400, sizeof(buffer));
       break;
     case HTTP_NOT_FOUND:
-      strscpy_P(buffer, (PGM_P)response_404, sizeof(buffer));
+      strscpy_P(buffer, response_404, sizeof(buffer));
       break;
     case HTTP_NOT_PERMITTED:
-      strscpy_P(buffer, (PGM_P)response_405, sizeof(buffer));
+      strscpy_P(buffer, response_405, sizeof(buffer));
       break;
     case HTTP_TIMEOUT:
-      strscpy_P(buffer, (PGM_P)response_408, sizeof(buffer));
+      strscpy_P(buffer, response_408, sizeof(buffer));
       break;
     case HTTP_NOT_IMPLEMENTED:
-      strscpy_P(buffer, (PGM_P)response_501, sizeof(buffer));
+      strscpy_P(buffer, response_501, sizeof(buffer));
       break;
     default:
-      strscpy_P(buffer, (PGM_P)response_500, sizeof(buffer));
+      strscpy_P(buffer, response_500, sizeof(buffer));
   };
   client.write(buffer);
 }

--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -177,7 +177,7 @@ void EthernetServer_TC::keypress() {
 }
 
 // Non-member callback wrapper for singleton
-void writeToClientBufferCallback(char *buffer, bool isFinished) {
+void writeToClientBufferCallback(const char *buffer, bool isFinished) {
   // The boolean value in the callback is true when the process is complete
   EthernetServer_TC::instance()->writeToClientBuffer(buffer, isFinished);
 }
@@ -218,7 +218,7 @@ void EthernetServer_TC::rootdir() {
 }
 
 // Write to the client buffer
-void EthernetServer_TC::writeToClientBuffer(char *buffer, bool isFinished) {
+void EthernetServer_TC::writeToClientBuffer(const char *buffer, bool isFinished) {
   // Write to client and return (ASSUME NULL-TERMINATED)
   client.write(buffer);
   if (isFinished) {
@@ -245,7 +245,7 @@ void EthernetServer_TC::sendHeadersForRootdir(int fileCount) {
 void EthernetServer_TC::testReadSpeed() {
   wdt_disable();
   const __FlashStringHelper *path = F("tstRdSpd.txt");
-  char temp[sizeof(path)];
+  char temp[15];
   strscpy_P(temp, path, sizeof(temp));
   // Create the file and write garbage
   file = SD_TC::instance()->open(temp, O_RDWR | O_CREAT | O_AT_END);
@@ -414,7 +414,7 @@ void EthernetServer_TC::sendHeadersWithSize(uint32_t size) {
         "Content-Encoding: identity\r\n"
         "Content-Language: en-US\r\n"
         "Access-Control-Allow-Origin: *\r\n");
-  char buffer[sizeof(response)];
+  char buffer[150];
   strscpy_P(buffer, response, sizeof(buffer));
   client.write(buffer);
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("Content-Length: %lu\r\n"), (unsigned long)size);
@@ -460,7 +460,7 @@ void EthernetServer_TC::sendResponse(int code) {
   const __FlashStringHelper *response_501 =
       F("HTTP/1.1 501 Not Implemented\r\n"
         "\r\n");
-  char buffer[sizeof(response_303)];  // Use longest of above responses
+  char buffer[100];  // Space for longest of above responses
   switch (code) {
     case HTTP_REDIRECT:
       strscpy_P(buffer, response_303, sizeof(buffer));

--- a/src/Devices/EthernetServer_TC.h
+++ b/src/Devices/EthernetServer_TC.h
@@ -47,7 +47,7 @@ public:
     return state;
   }
   void loop();
-  void writeToClientBuffer(char*, bool);
+  void writeToClientBuffer(const char*, bool);
   void sendHeadersForRootdir(int);
 
 private:

--- a/src/Devices/LiquidCrystal_TC.cpp
+++ b/src/Devices/LiquidCrystal_TC.cpp
@@ -68,6 +68,6 @@ void LiquidCrystal_TC::writeLine(const char* text, uint16_t line) {
 void LiquidCrystal_TC::writeLine(const __FlashStringHelper* text, uint16_t line) {
   // copy from program memory to SRAM and then call other function
   char buffer[17];
-  strscpy_P(buffer, (PGM_P)text, sizeof(buffer));
+  strscpy_P(buffer, text, sizeof(buffer));
   writeLine(buffer, line);
 }

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -43,7 +43,7 @@ void PHProbe::clearCalibration() {
 void PHProbe::sendSlopeRequest() {
   // Sending request for Calibration Slope
   Serial1.print(F("SLOPE,?\r"));
-  strscpy_P(slopeResponse, (PGM_P)F("       Slope requested!"), sizeof(slopeResponse));
+  strscpy_P(slopeResponse, F("       Slope requested!"), sizeof(slopeResponse));
 }
 
 void PHProbe::getSlope(char *buffer, int size) {

--- a/src/Devices/SD_TC.cpp
+++ b/src/Devices/SD_TC.cpp
@@ -167,11 +167,9 @@ bool SD_TC::listFile(File* myFile, void* userData) {
 #endif
 }
 
-bool SD_TC::listRootToBuffer(void (*callWhenFull)(char*, bool)) {
+bool SD_TC::listRootToBuffer(void (*callWhenFull)(const char*, bool)) {
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  static const char notImplemented[] PROGMEM = "Root directory not supported by CI framework.\r\n";
-  char buffer[sizeof(notImplemented)];
-  memcpy(buffer, (PGM_P)notImplemented, sizeof(notImplemented));
+  const char buffer[] = "Root directory not supported by CI framework.\r\n";
   callWhenFull(buffer, true);
   return true;
 #else

--- a/src/Devices/SD_TC.h
+++ b/src/Devices/SD_TC.h
@@ -24,7 +24,7 @@ public:
   void appendToLog(const char* line);
   bool exists(const char* path);
   bool format();
-  bool listRootToBuffer(void (*callWhenFull)(char*, bool));
+  bool listRootToBuffer(void (*callWhenFull)(const char*, bool));
   bool countFiles(void (*callWhenFinished)(int));
   bool mkdir(const char* path);
   File open(const char* path, oflag_t oflag = 0x00);

--- a/src/Devices/TemperatureControl.cpp
+++ b/src/Devices/TemperatureControl.cpp
@@ -42,7 +42,7 @@ void TemperatureControl::enableHeater(bool flag) {
     delete _instance;
     _instance = nullptr;
     char buffer[7];
-    strscpy_P(buffer, (flag ? (PGM_P)F("true)") : (PGM_P)F("false)")), sizeof(buffer));
+    strscpy_P(buffer, (flag ? F("true)") : F("false)")), sizeof(buffer));
     serial(F("TemperatureControl::enableHeater(%s"), buffer);
   }
 }
@@ -87,7 +87,7 @@ TemperatureControl::TemperatureControl() {
   digitalWrite(TEMP_CONTROL_PIN, TURN_SOLENOID_OFF);
   char buffer1[8];
   char buffer2[10];
-  strscpy_P(buffer1, (this->isHeater() ? (PGM_P)F("Heater") : (PGM_P)F("Chiller")), sizeof(buffer1));
+  strscpy_P(buffer1, (this->isHeater() ? F("Heater") : F("Chiller")), sizeof(buffer1));
   floattostrf(targetTemperature, 5, 2, buffer2, sizeof(buffer2));
   serial(F("%s starts with solenoid off with target temperature of %s C"), buffer1, buffer2);
 }

--- a/src/TC_util.cpp
+++ b/src/TC_util.cpp
@@ -33,7 +33,7 @@ int strscpy_P(char *destination, const __FlashStringHelper *source_F, unsigned l
     // Put a null terminator in the final byte
     *((char *)memcpy_P(destination, source, sizeOfDestination - 1) + sizeOfDestination - 1) = '\0';
     // TODO: Log a WARNING that a string was truncated
-    serial(F("WARNING! String \"%s\" was truncated to \"%s\""), (PGM_P)source, destination);
+    serial(F("WARNING! String (P) \"%s\" was truncated to \"%s\""), (PGM_P)source, destination);
     return 1;
   }
 }

--- a/src/TC_util.cpp
+++ b/src/TC_util.cpp
@@ -21,9 +21,10 @@ int strscpy(char *destination, const char *source, unsigned long sizeOfDestinati
 }
 
 // In this function, the source is treated as an address in PROGMEM, not RAM
-// Example: strscpy_P(buffer, (PGM_P)F("some string here"), sizeof(buffer));
-int strscpy_P(char *destination, const char *source, unsigned long sizeOfDestination) {
-  unsigned long sourceLength = strnlen(source, sizeOfDestination);
+// Example: strscpy_P(buffer, F("some string here"), sizeof(buffer));
+int strscpy_P(char *destination, const __FlashStringHelper *source_F, unsigned long sizeOfDestination) {
+  PGM_P source = (PGM_P)source_F;
+  unsigned long sourceLength = strlen_P(source);
   if (sourceLength < sizeOfDestination) {
     // Put a null terminator in the final byte
     *((char *)memcpy_P(destination, source, sourceLength) + sourceLength) = '\0';

--- a/src/TC_util.h
+++ b/src/TC_util.h
@@ -24,6 +24,6 @@ extern size_t strnlen(const char *s, size_t n);
 #endif
 
 int strscpy(char *destination, const char *source, unsigned long sizeOfDestination);
-int strscpy_P(char *destination, const char *source, unsigned long sizeOfDestination);
+int strscpy_P(char *destination, const __FlashStringHelper *source, unsigned long sizeOfDestination);
 int floattostrf(double float_value, int min_width, int num_digits_after_decimal, char *buffer,
                 unsigned long buffer_size);

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -175,7 +175,7 @@ void TankController::serialEvent1() {
  * Set the next state
  */
 void TankController::setNextState(UIState *newState, bool update) {
-  COUT("TankController::setNextState() from " << (nextState ? nextState->name() : "nullptr") << " to "
+  COUT("TankController::setNextState() from " << (nextState ? (PGM_P)nextState->name() : "nullptr") << " to "
                                               << newState->name());
   assert(nextState == nullptr);
   nextState = newState;
@@ -269,7 +269,7 @@ void TankController::writeDataToSD() {
   floattostrf(pPID->getKd(), 8, 1, kd, sizeof(kd));
   const __FlashStringHelper *header = F("time,tankid,temp,temp setpoint,pH,pH setpoint,onTime,Kp,Ki,Kd");
   const __FlashStringHelper *format = F("%02i/%02i/%4i %02i:%02i:%02i, %3i, %s, %s, %s, %s, %4lu, %s, %s, %s");
-  char header_buffer[sizeof(header)];
+  char header_buffer[64];
   strscpy_P(header_buffer, header, sizeof(header_buffer));
   char buffer[128];
   int length;

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -267,10 +267,10 @@ void TankController::writeDataToSD() {
   floattostrf(pPID->getKp(), 8, 1, kp, sizeof(kp));
   floattostrf(pPID->getKi(), 8, 1, ki, sizeof(ki));
   floattostrf(pPID->getKd(), 8, 1, kd, sizeof(kd));
-  static const char header[] PROGMEM = "time,tankid,temp,temp setpoint,pH,pH setpoint,onTime,Kp,Ki,Kd";
-  static const char format[] PROGMEM = "%02i/%02i/%4i %02i:%02i:%02i, %3i, %s, %s, %s, %s, %4lu, %s, %s, %s";
+  const __FlashStringHelper *header = F("time,tankid,temp,temp setpoint,pH,pH setpoint,onTime,Kp,Ki,Kd");
+  const __FlashStringHelper *format = F("%02i/%02i/%4i %02i:%02i:%02i, %3i, %s, %s, %s, %s, %4lu, %s, %s, %s");
   char header_buffer[sizeof(header)];
-  strscpy_P(header_buffer, (PGM_P)header, sizeof(header_buffer));
+  strscpy_P(header_buffer, header, sizeof(header_buffer));
   char buffer[128];
   int length;
   length = snprintf_P(buffer, sizeof(buffer), (PGM_P)format, (uint16_t)dtNow.month(), (uint16_t)dtNow.day(),

--- a/src/UIState/PHCalibrationHigh.cpp
+++ b/src/UIState/PHCalibrationHigh.cpp
@@ -9,7 +9,7 @@
 void PHCalibrationHigh::setValue(float value) {
   PHProbe::instance()->setHighpointCalibration(value);
   char buffer[17];
-  strscpy_P(buffer, (PGM_P)F("New High="), sizeof(buffer));
+  strscpy_P(buffer, F("New High="), sizeof(buffer));
   floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New High=12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
   returnToMainMenu(3000);

--- a/src/UIState/PHCalibrationLow.cpp
+++ b/src/UIState/PHCalibrationLow.cpp
@@ -12,7 +12,7 @@
 void PHCalibrationLow::setValue(float value) {
   PHProbe::instance()->setLowpointCalibration(value);
   char buffer[17];
-  strscpy_P(buffer, (PGM_P)F("New Low = "), sizeof(buffer));
+  strscpy_P(buffer, F("New Low = "), sizeof(buffer));
   floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New Low = 12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
   this->setNextState((UIState*)new Wait(tc, 3000, new PHCalibrationHigh(tc)));

--- a/src/UIState/PHCalibrationMid.cpp
+++ b/src/UIState/PHCalibrationMid.cpp
@@ -12,7 +12,7 @@
 void PHCalibrationMid::setValue(float value) {
   PHProbe::instance()->setMidpointCalibration(value);
   char buffer[17];
-  strscpy_P(buffer, (PGM_P)F("New Mid = "), sizeof(buffer));
+  strscpy_P(buffer, F("New Mid = "), sizeof(buffer));
   floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New Mid = 12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
   this->setNextState((UIState*)new Wait(tc, 3000, new PHCalibrationLow(tc)));

--- a/test/StringsTest.cpp
+++ b/test/StringsTest.cpp
@@ -54,7 +54,7 @@ unittest(stringCopy_P) {
   String serialOutput;
   serial("This line of code initializes SD_TC so it won't pollute future logs.");
 
-  static const char source[11] PROGMEM = "stringtest";
+  const __FlashStringHelper* source = F("stringtest");
   char dest1[9];
   char dest2[] = "012345678";
   char dest3[] = "0123456789abc";

--- a/test/StringsTest.cpp
+++ b/test/StringsTest.cpp
@@ -65,14 +65,14 @@ unittest(stringCopy_P) {
   assertEqual("stringte", dest1);
   assertEqual('\0', dest1[8]);
   serialOutput = state->serialPort[0].dataOut;
-  assertEqual("WARNING! String \"stringtest\" was truncated to \"stringte\"\r\n", serialOutput.c_str());
+  assertEqual("WARNING! String (P) \"stringtest\" was truncated to \"stringte\"\r\n", serialOutput.c_str());
 
   state->serialPort[0].dataOut = "";  // the history of data written
   assertEqual(1, strscpy_P(dest2, source, sizeof(dest2)));
   assertEqual("stringtes", dest2);
   assertEqual('\0', dest2[9]);
   serialOutput = state->serialPort[0].dataOut;
-  assertEqual("WARNING! String \"stringtest\" was truncated to \"stringtes\"\r\n", serialOutput.c_str());
+  assertEqual("WARNING! String (P) \"stringtest\" was truncated to \"stringtes\"\r\n", serialOutput.c_str());
 
   state->serialPort[0].dataOut = "";  // the history of data written
   assertEqual(1, strscpy_P(dest3, source, 9));
@@ -82,7 +82,7 @@ unittest(stringCopy_P) {
   assertEqual('a', dest3[10]);
   assertEqual('\0', dest3[13]);
   serialOutput = state->serialPort[0].dataOut;
-  assertEqual("WARNING! String \"stringtest\" was truncated to \"stringte\"\r\n", serialOutput.c_str());
+  assertEqual("WARNING! String (P) \"stringtest\" was truncated to \"stringte\"\r\n", serialOutput.c_str());
 
   state->serialPort[0].dataOut = "";  // the history of data written
   assertEqual(0, strscpy_P(dest4, source, sizeof(dest4)));


### PR DESCRIPTION
Prior usage was `const char *` which is equivalent to `PGM_P` so we don't catch errors with SRAM vs FLASH. By using __Flash_StringHelper (a class), the compiler should catch more errors.