### PR TITLE
Use HTTP instead of HTTPS for Flutter app

### DIFF
--- a/src/Devices/EthernetServer_TC.cpp
+++ b/src/Devices/EthernetServer_TC.cpp
@@ -502,7 +502,7 @@ void EthernetServer_TC::sendDisplayRedirect() {
 void EthernetServer_TC::sendHomeRedirect() {
   const __FlashStringHelper *response_303 =
       F("HTTP/1.1 303 See Other\r\n"
-        "Location: https://open-acidification.github.io/TankControllerManager/\r\n"
+        "Location: http://oap.cs.wallawalla.edu/\r\n"
         "Access-Control-Allow-Origin: *\r\n"
         "\r\n");
   strscpy_P(buffer, response_303, sizeof(buffer));

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -589,7 +589,7 @@ unittest(home) {
   }
   const char expectedResponse[] =
       "HTTP/1.1 303 See Other\r\n"
-      "Location: https://open-acidification.github.io/TankControllerManager/\r\n"
+      "Location: http://oap.cs.wallawalla.edu/\r\n"
       "Access-Control-Allow-Origin: *\r\n"
       "\r\n";
   assertEqual(expectedResponse, response);


### PR DESCRIPTION
 This should avoid the mixed content blocking problems (fix #362).