### PR TITLE
Don't call PushingBox if there is not a device identifier

### DIFF
--- a/examples/TankController/TankController.ino
+++ b/examples/TankController/TankController.ino
@@ -4,7 +4,9 @@
  * used in the mock environment.
  */
 
-const char pushingBoxID[] = "PushingBoxIdentifier";  // <<== REPLACE THIS!
+// For PushingBox to work you need to provide an ID.
+// If it remains empty, then no data will be sent.
+const char pushingBoxID[] = "";
 
 #include "TankController.h"
 

--- a/src/Devices/PushingBox.cpp
+++ b/src/Devices/PushingBox.cpp
@@ -24,7 +24,7 @@ PushingBox* PushingBox::instance(const char* pushingBoxID) {
 
 //  instance methods
 PushingBox::PushingBox(const char* pushingBoxID) {
-  DevID = pushingBoxID;
+  deviceID = pushingBoxID;
 }
 
 void PushingBox::loop() {
@@ -61,6 +61,13 @@ void PushingBox::loop() {
 }
 
 void PushingBox::sendData() {
+  if (deviceID == nullptr) {
+    return;
+  }
+  if (strlen(deviceID) == 0) {
+    serial(F("Provide a PushingBox ID to send data to PushingBox"));
+    return;
+  }
   int tankID = EEPROM_TC::instance()->getTankID();
   if (!tankID) {
     serial(F("Set Tank ID in order to send data to PushingBox"));
@@ -73,7 +80,7 @@ void PushingBox::sendData() {
         "Host: api.pushingbox.com\r\n"
         "Connection: close\r\n"
         "\r\n";
-    snprintf_P(buffer, sizeof(buffer), (PGM_P)format, DevID, tankID);
+    snprintf_P(buffer, sizeof(buffer), (PGM_P)format, deviceID, tankID);
   } else {
     static const char format[] PROGMEM =
         "GET /pushingbox?devid=%s&tankid=%i&tempData=%i.%02i&pHdata=%i.%03i HTTP/1.1\r\n"
@@ -83,7 +90,7 @@ void PushingBox::sendData() {
     // look up tankid, temperature, ph
     float temperature = TempProbe_TC::instance()->getRunningAverage();
     float pH = PHProbe::instance()->getPh();
-    snprintf_P(buffer, sizeof(buffer), (PGM_P)format, DevID, tankID, (int)temperature,
+    snprintf_P(buffer, sizeof(buffer), (PGM_P)format, deviceID, tankID, (int)temperature,
                (int)(temperature * 100 + 0.5) % 100, (int)pH, (int)(pH * 1000) % 1000);
   }
   size_t i = 0;
@@ -96,7 +103,7 @@ void PushingBox::sendData() {
   serial(F("%s"), buffer);
   buffer[i] = '\r';
   serial(F("attempting to connect to PushingBox..."));
-  if (client.connected() || client.connect(server, 80)) {
+  if (client.connected() || client.connect(serverDomain, 80)) {
     serial(F("connected"));
     client.write(buffer, strnlen(buffer, sizeof(buffer)));
   } else {

--- a/src/Devices/PushingBox.cpp
+++ b/src/Devices/PushingBox.cpp
@@ -64,7 +64,7 @@ void PushingBox::sendData() {
   if (deviceID == nullptr) {
     return;
   }
-  if (strlen(deviceID) == 0) {
+  if (strnlen(deviceID, 64) == 0) {
     serial(F("Provide a PushingBox ID to send data to PushingBox"));
     return;
   }

--- a/src/Devices/PushingBox.h
+++ b/src/Devices/PushingBox.h
@@ -17,7 +17,7 @@ public:
     return serverDomain;
   }
   void loop();
-  void setDeviceID(const char* id) {
+  void setDeviceID(const char *id) {
     deviceID = id;
   }
 

--- a/src/Devices/PushingBox.h
+++ b/src/Devices/PushingBox.h
@@ -13,10 +13,13 @@ public:
   EthernetClient *getClient() {
     return &client;
   }
-  const char *getServer() {
-    return server;
+  const char *getServerDomain() {
+    return serverDomain;
   }
   void loop();
+  void setDeviceID(const char* id) {
+    deviceID = id;
+  }
 
 private:
   // class variables
@@ -24,10 +27,10 @@ private:
 
   // instance variables
   EthernetClient client;
-  const char *DevID = nullptr;  // DeviceID assigned by PushingBox and passed-in from TankController.ino
+  const char *deviceID = nullptr;  // DeviceID assigned by PushingBox and passed-in from TankController.ino
   // wait a bit for first reading (https://github.com/Open-Acidification/TankController/issues/179)
   uint32_t nextSendTime = 70000;
-  const char *server = "api.pushingbox.com";
+  const char *serverDomain = "api.pushingbox.com";
 
   // instance method
   void sendData();

--- a/src/TC_util.cpp
+++ b/src/TC_util.cpp
@@ -76,8 +76,3 @@ float strtofloat(const char *buffer) {
   }
   return integerPortion + fractionalPortion / pow(10, digitsAfterDecimal);
 }
-
-void writeSerial1(const char *data) {
-  GODMODE()->serialPort[1].dataIn = data;      // the queue of data waiting to be read
-  TankController::instance()->serialEvent1();  // fake interrupt
-}

--- a/src/TC_util.cpp
+++ b/src/TC_util.cpp
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "Devices/Serial_TC.h"
+#include "TankController.h"
 
 // Example: strscpy(buffer, source, sizeof(buffer));
 int strscpy(char *destination, const char *source, unsigned long sizeOfDestination) {
@@ -74,4 +75,9 @@ float strtofloat(const char *buffer) {
     }
   }
   return integerPortion + fractionalPortion / pow(10, digitsAfterDecimal);
+}
+
+void writeSerial1(const char *data) {
+  GODMODE()->serialPort[1].dataIn = data;      // the queue of data waiting to be read
+  TankController::instance()->serialEvent1();  // fake interrupt
 }

--- a/src/TC_util.h
+++ b/src/TC_util.h
@@ -28,4 +28,3 @@ int strscpy_P(char *destination, const __FlashStringHelper *source, unsigned lon
 int floattostrf(double float_value, int min_width, int num_digits_after_decimal, char *buffer,
                 unsigned long buffer_size);
 float strtofloat(const char *buffer);
-void writeSerial1(const char *data);

--- a/src/TC_util.h
+++ b/src/TC_util.h
@@ -28,3 +28,4 @@ int strscpy_P(char *destination, const __FlashStringHelper *source, unsigned lon
 int floattostrf(double float_value, int min_width, int num_digits_after_decimal, char *buffer,
                 unsigned long buffer_size);
 float strtofloat(const char *buffer);
+void writeSerial1(const char *data);

--- a/test/PushingBoxTest.cpp
+++ b/test/PushingBoxTest.cpp
@@ -61,11 +61,11 @@ unittest(SendData) {
   // set temperature
   TemperatureControl::instance()->setTargetTemperature(20.25);
   tempProbe->setTemperature(20.25, true);
-  tempProbe->setCorrection(0.0);
-  for (int i = 0; i < 100; ++i) {
-    delay(1000);
-    tempProbe->getRunningAverage();
-  }
+  // tempProbe->setCorrection(0.0);
+  // for (int i = 0; i < 100; ++i) {
+  //   delay(1000);
+  //   tempProbe->getRunningAverage();
+  // }
 
   // set pH
   state->serialPort[1].dataIn = "7.125\r";  // the queue of data waiting to be read
@@ -83,6 +83,7 @@ unittest(SendData) {
   String bufferResult;
   bool flag = false;
   for (int i = 0; i < buffer.size(); i++) {
+    // Capture everything after the first 'G'
     flag = flag || buffer[i] == 'G';
     if (flag) {
       bufferResult += buffer[i];


### PR DESCRIPTION
This can reduce the noise to serial when we are working with a test device.