### PR TITLE
pH Probe Calibration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
-# gem 'arduino_ci', github: 'Arduino-CI/arduino_ci', branch: 'master'
-gem 'arduino_ci', github: 'jgfoster/arduino_ci', branch: 'makefile'
+gem 'arduino_ci', github: 'Arduino-CI/arduino_ci', branch: 'master'
+# gem 'arduino_ci', github: 'jgfoster/arduino_ci', branch: 'makefile'
 
 # Following are alternate ways to reference a specific tag or commit
 # This is helpful when a change to arduino_ci breaks the tests

--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5898 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
+bundle exec arduino_ci.rb --min-free-space=5780 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
 result="${PIPESTATUS[0]}"
 exit "$result"

--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5818 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
+bundle exec arduino_ci.rb --min-free-space=5838 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
 result="${PIPESTATUS[0]}"
 exit "$result"

--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -3,6 +3,6 @@
 cp extras/scripts/p*-commit .git/hooks/
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5838 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
+bundle exec arduino_ci.rb --min-free-space=5830 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
 result="${PIPESTATUS[0]}"
 exit "$result"

--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5736 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
+bundle exec arduino_ci.rb --min-free-space=5818 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
 result="${PIPESTATUS[0]}"
 exit "$result"

--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5780 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
+bundle exec arduino_ci.rb --min-free-space=5736 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
 result="${PIPESTATUS[0]}"
 exit "$result"

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -43,30 +43,30 @@ void PHProbe::clearCalibration() {
 void PHProbe::sendCalibrationRequest() {
   // Sending request for calibration status
   Serial1.print(F("Cal,?\r"));
-  strscpy_P(probeResponse, F("     Calib requested!"), sizeof(probeResponse));
+  strscpy_P(calibrationResponse, F("R"), sizeof(calibrationResponse));
 }
 
 void PHProbe::getCalibration(char *buffer, int size) {
   // for example "?Cal,2" or "     Calib requested!"
-  if (strnlen(probeResponse, sizeof(probeResponse)) > 5) {  // Flawfinder: ignore
-    strscpy(buffer, probeResponse + 5, size);               // Flawfinder: ignore
+  if (strcmp_P(calibrationResponse, PSTR("R"))) {
+    strscpy_P(buffer, F("Calib requested!"), sizeof(buffer));
   } else {
-    buffer[0] = '\0';
+    strscpy(buffer, calibrationResponse, size);
   }
 }
 
 void PHProbe::sendSlopeRequest() {
   // Sending request for Calibration Slope
   Serial1.print(F("SLOPE,?\r"));
-  strscpy_P(probeResponse, F("       Slope requested!"), sizeof(probeResponse));
+  strscpy_P(slopeResponse, F("R"), sizeof(slopeResponse));
 }
 
 void PHProbe::getSlope(char *buffer, int size) {
-  // for example "?SLOPE,99.7,100.3, -0.89" or "       Slope requested!"
-  if (strnlen(probeResponse, sizeof(probeResponse)) > 10) {  // Flawfinder: ignore
-    strscpy(buffer, probeResponse + 7, size);                // Flawfinder: ignore
+  // for example "99.7,100.3, -0.89" or "R"
+  if (strcmp_P(slopeResponse, PSTR("R"))) {
+    strscpy_P(buffer, F("Slope requested!"), sizeof(buffer));
   } else {
-    buffer[0] = '\0';
+    strscpy(buffer, slopeResponse, size);
   }
 }
 
@@ -89,10 +89,10 @@ void PHProbe::serialEvent1() {
         serial(F("PHProbe serialEvent1: \"%s\""), string.c_str());
         if (string.length() > 7 && string.substring(0, 7) == "?SLOPE,") {
           // for example "?SLOPE,16.1,100.0"
-          strscpy(probeResponse, string.c_str(), sizeof(probeResponse));  // Flawfinder: ignore
+          strscpy(slopeResponse, string.c_str() + 7, sizeof(slopeResponse));  // Flawfinder: ignore
         } else if (string.length() > 5 && string.substring(0, 5) == "?Cal,") {
           // for example "?Cal,2"
-          strscpt(probeResponse, string.c_str(), sizeof(probeResponse));  // Flawfinder: ignore
+          strscpy(calibrationResponse, string.c_str() + 5, sizeof(calibrationResponse));  // Flawfinder: ignore
         }
       }
     }

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -74,7 +74,7 @@ void PHProbe::sendSlopeRequest() {
   Serial1.print(F("SLOPE,?\r"));
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
   GodmodeState *state = GODMODE();
-  char buffer[10];
+  char buffer[25];
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?SLOPE,99.7,100.3,-0.89\r"));
   state->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
 #endif

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -51,10 +51,10 @@ void PHProbe::clearCalibration() {
 
 void PHProbe::sendCalibrationRequest() {
   // Sending request for calibration status
-  Serial1.print(F("Cal,?\r"));
+  Serial1.print(F("CAL,?\r"));
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
   char buffer[10];
-  snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?Cal,%i\r"), this->calibrationPoints);
+  snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?CAL,%i\r"), this->calibrationPoints);
   GODMODE()->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
 #endif
   strscpy_P(calibrationResponse, F("Requesting..."), sizeof(calibrationResponse));
@@ -107,8 +107,8 @@ void PHProbe::serialEvent1() {
         if (string.length() > 7 && memcmp_P(string.c_str(), F("?SLOPE,"), 7) == 0) {
           // for example "?SLOPE,16.1,100.0"
           strscpy(slopeResponse, string.c_str() + 7, sizeof(slopeResponse));  // Flawfinder: ignore
-        } else if (string.length() > 5 && memcmp_P(string.c_str(), F("?Cal,"), 5) == 0) {
-          // for example "?Cal,2"
+        } else if (string.length() > 5 && memcmp_P(string.c_str(), F("?CAL,"), 5) == 0) {
+          // for example "?CAL,2"
           snprintf_P(calibrationResponse, sizeof(calibrationResponse), PSTR("%s point"),
                      string.c_str() + 5);  // Flawfinder: ignore
         }

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -44,47 +44,28 @@ PHProbe::PHProbe() {
 
 void PHProbe::clearCalibration() {
   Serial1.print(F("Cal,clear\r"));  // send that string to the Atlas Scientific product
-#if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  this->calibrationPoints = 0;
-#endif
 }
 
 void PHProbe::sendCalibrationRequest() {
   // Sending request for calibration status
   Serial1.print(F("CAL,?\r"));
-#if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  char buffer[10];
-  snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?CAL,%i\r"), this->calibrationPoints);
-  GODMODE()->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
-#endif
   strscpy_P(calibrationResponse, F("Requesting..."), sizeof(calibrationResponse));
 }
 
 void PHProbe::getCalibration(char *buffer, int size) {
   // for example "2" or "Requesting..."
   strscpy(buffer, calibrationResponse, size);
-#if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  TankController::instance()->serialEvent1();  // fake interrupt
-#endif
 }
 
 void PHProbe::sendSlopeRequest() {
   // Sending request for Calibration Slope
   Serial1.print(F("SLOPE,?\r"));
-#if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  char buffer[25];
-  snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?SLOPE,99.7,100.3,-0.89\r"));
-  GODMODE()->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
-#endif
   strscpy_P(slopeResponse, F("Requesting..."), sizeof(slopeResponse));
 }
 
 void PHProbe::getSlope(char *buffer, int size) {
   // for example "99.7,100.3, -0.89" or "Requesting..."
   strscpy(buffer, slopeResponse, size);
-#if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  TankController::instance()->serialEvent1();  // fake interrupt
-#endif
 }
 
 /**
@@ -136,9 +117,6 @@ void PHProbe::setHighpointCalibration(float highpoint) {
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("Cal,High,%i.%03i\r"), (int)highpoint,
              (int)(highpoint * 1000 + 0.5) % 1000);
   Serial1.print(buffer);  // send that string to the Atlas Scientific product
-#if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  this->calibrationPoints += 1;
-#endif
   serial(F("PHProbe::setHighpointCalibration(%i.%03i)"), (int)highpoint, (int)(highpoint * 1000) % 1000);
 }
 
@@ -146,9 +124,6 @@ void PHProbe::setLowpointCalibration(float lowpoint) {
   char buffer[16];
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("Cal,low,%i.%03i\r"), (int)lowpoint, (int)(lowpoint * 1000 + 0.5) % 1000);
   Serial1.print(buffer);  // send that string to the Atlas Scientific product
-#if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  this->calibrationPoints += 1;
-#endif
   serial(F("PHProbe::setLowpointCalibration(%i.%03i)"), (int)lowpoint, (int)(lowpoint * 1000) % 1000);
 }
 
@@ -156,15 +131,16 @@ void PHProbe::setMidpointCalibration(float midpoint) {
   char buffer[16];
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("Cal,mid,%i.%03i\r"), (int)midpoint, (int)(midpoint * 1000 + 0.5) % 1000);
   Serial1.print(buffer);  // send that string to the Atlas Scientific product
-#if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  this->calibrationPoints = 1;
-#endif
   serial(F("PHProbe::setMidpointCalibration(%i.%03i)"), (int)midpoint, (int)(midpoint * 1000) % 1000);
 }
 
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
-void PHProbe::setCalibrationPoints(int newValue) {
-  this->calibrationPoints = newValue;
+void PHProbe::setCalibration(int calibrationPoints) {
+  char buffer[10];
+  snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?CAL,%i\r"), calibrationPoints);
+  GODMODE()->serialPort[1].dataIn = buffer;    // the queue of data waiting to be read
+  TankController::instance()->serialEvent1();  // fake interrupt to update the calibration reading
+  TankController::instance()->loop();          // update the controls based on the current readings
 }
 void PHProbe::setPh(float newValue) {
   char buffer[10];

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -56,8 +56,7 @@ void PHProbe::sendCalibrationRequest() {
   GodmodeState *state = GODMODE();
   char buffer[10];
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?Cal,%i\r"), this->calibrationPoints);
-  state->serialPort[1].dataIn = buffer;        // the queue of data waiting to be read
-  TankController::instance()->serialEvent1();  // fake interrupt
+  state->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
 #endif
   strscpy_P(calibrationResponse, F("Requesting..."), sizeof(calibrationResponse));
 }
@@ -65,6 +64,9 @@ void PHProbe::sendCalibrationRequest() {
 void PHProbe::getCalibration(char *buffer, int size) {
   // for example "2" or "Requesting..."
   strscpy(buffer, calibrationResponse, size);
+#if defined(ARDUINO_CI_COMPILATION_MOCKS)
+  TankController::instance()->serialEvent1();  // fake interrupt
+#endif
 }
 
 void PHProbe::sendSlopeRequest() {
@@ -74,8 +76,7 @@ void PHProbe::sendSlopeRequest() {
   GodmodeState *state = GODMODE();
   char buffer[10];
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?SLOPE,99.7,100.3,-0.89\r"));
-  state->serialPort[1].dataIn = buffer;        // the queue of data waiting to be read
-  TankController::instance()->serialEvent1();  // fake interrupt
+  state->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
 #endif
   strscpy_P(slopeResponse, F("Requesting..."), sizeof(slopeResponse));
 }
@@ -83,6 +84,9 @@ void PHProbe::sendSlopeRequest() {
 void PHProbe::getSlope(char *buffer, int size) {
   // for example "99.7,100.3, -0.89" or "Requesting..."
   strscpy(buffer, slopeResponse, size);
+#if defined(ARDUINO_CI_COMPILATION_MOCKS)
+  TankController::instance()->serialEvent1();  // fake interrupt
+#endif
 }
 
 /**
@@ -163,11 +167,6 @@ void PHProbe::setMidpointCalibration(float midpoint) {
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
 void PHProbe::setCalibrationPoints(int newValue) {
   this->calibrationPoints = newValue;
-  GodmodeState *state = GODMODE();
-  char buffer[10];
-  snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?Cal,%i\r"), this->calibrationPoints);
-  state->serialPort[1].dataIn = buffer;        // the queue of data waiting to be read
-  TankController::instance()->serialEvent1();  // fake interrupt
 }
 
 void PHProbe::setPh(float newValue) {

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -163,6 +163,11 @@ void PHProbe::setMidpointCalibration(float midpoint) {
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
 void PHProbe::setCalibrationPoints(int newValue) {
   this->calibrationPoints = newValue;
+  GodmodeState *state = GODMODE();
+  char buffer[10];
+  snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?Cal,%i\r"), this->calibrationPoints);
+  state->serialPort[1].dataIn = buffer;        // the queue of data waiting to be read
+  TankController::instance()->serialEvent1();  // fake interrupt
 }
 
 void PHProbe::setPh(float newValue) {

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -48,7 +48,7 @@ void PHProbe::sendCalibrationRequest() {
 
 void PHProbe::getCalibration(char *buffer, int size) {
   // for example "?Cal,2" or "     Calib requested!"
-  if (strcmp_P(calibrationResponse, PSTR("R"))) {
+  if (strcmp_P(calibrationResponse, PSTR("R")) == 0) {
     strscpy_P(buffer, F("Calib requested!"), sizeof(buffer));
   } else {
     strscpy(buffer, calibrationResponse, size);
@@ -63,7 +63,7 @@ void PHProbe::sendSlopeRequest() {
 
 void PHProbe::getSlope(char *buffer, int size) {
   // for example "99.7,100.3, -0.89" or "R"
-  if (strcmp_P(slopeResponse, PSTR("R"))) {
+  if (strcmp_P(slopeResponse, PSTR("R")) == 0) {
     strscpy_P(buffer, F("Slope requested!"), sizeof(buffer));
   } else {
     strscpy(buffer, slopeResponse, size);

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -53,10 +53,9 @@ void PHProbe::sendCalibrationRequest() {
   // Sending request for calibration status
   Serial1.print(F("Cal,?\r"));
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  GodmodeState *state = GODMODE();
   char buffer[10];
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?Cal,%i\r"), this->calibrationPoints);
-  state->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
+  GODMODE()->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
 #endif
   strscpy_P(calibrationResponse, F("Requesting..."), sizeof(calibrationResponse));
 }
@@ -73,10 +72,9 @@ void PHProbe::sendSlopeRequest() {
   // Sending request for Calibration Slope
   Serial1.print(F("SLOPE,?\r"));
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  GodmodeState *state = GODMODE();
   char buffer[25];
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?SLOPE,99.7,100.3,-0.89\r"));
-  state->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
+  GODMODE()->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
 #endif
   strscpy_P(slopeResponse, F("Requesting..."), sizeof(slopeResponse));
 }
@@ -168,7 +166,6 @@ void PHProbe::setMidpointCalibration(float midpoint) {
 void PHProbe::setCalibrationPoints(int newValue) {
   this->calibrationPoints = newValue;
 }
-
 void PHProbe::setPh(float newValue) {
   char buffer[10];
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("%i.%03i\r"), (int)newValue, (int)(newValue * 1000 + 0.5) % 1000);

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -40,16 +40,31 @@ void PHProbe::clearCalibration() {
   Serial1.print(F("Cal,clear\r"));  // send that string to the Atlas Scientific product
 }
 
+void PHProbe::sendCalibrationRequest() {
+  // Sending request for calibration status
+  Serial1.print(F("Cal,?\r"));
+  strscpy_P(probeResponse, F("     Calib requested!"), sizeof(probeResponse));
+}
+
+void PHProbe::getCalibration(char *buffer, int size) {
+  // for example "?Cal,2" or "     Calib requested!"
+  if (strnlen(probeResponse, sizeof(probeResponse)) > 5) {  // Flawfinder: ignore
+    strscpy(buffer, probeResponse + 5, size);               // Flawfinder: ignore
+  } else {
+    buffer[0] = '\0';
+  }
+}
+
 void PHProbe::sendSlopeRequest() {
   // Sending request for Calibration Slope
   Serial1.print(F("SLOPE,?\r"));
-  strscpy_P(slopeResponse, F("       Slope requested!"), sizeof(slopeResponse));
+  strscpy_P(probeResponse, F("       Slope requested!"), sizeof(probeResponse));
 }
 
 void PHProbe::getSlope(char *buffer, int size) {
-  // for example "?SLOPE,99.7,100.3, -0.89"
-  if (strnlen(slopeResponse, sizeof(slopeResponse)) > 10) {  // Flawfinder: ignore
-    strscpy(buffer, slopeResponse + 7, size);                // Flawfinder: ignore
+  // for example "?SLOPE,99.7,100.3, -0.89" or "       Slope requested!"
+  if (strnlen(probeResponse, sizeof(probeResponse)) > 10) {  // Flawfinder: ignore
+    strscpy(buffer, probeResponse + 7, size);                // Flawfinder: ignore
   } else {
     buffer[0] = '\0';
   }
@@ -74,7 +89,10 @@ void PHProbe::serialEvent1() {
         serial(F("PHProbe serialEvent1: \"%s\""), string.c_str());
         if (string.length() > 7 && string.substring(0, 7) == "?SLOPE,") {
           // for example "?SLOPE,16.1,100.0"
-          strscpy(slopeResponse, string.c_str(), sizeof(slopeResponse));  // Flawfinder: ignore
+          strscpy(probeResponse, string.c_str(), sizeof(probeResponse));  // Flawfinder: ignore
+        } else if (string.length() > 5 && string.substring(0, 5) == "?Cal,") {
+          // for example "?Cal,2"
+          strscpt(probeResponse, string.c_str(), sizeof(probeResponse));  // Flawfinder: ignore
         }
       }
     }

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -49,7 +49,7 @@ void PHProbe::sendCalibrationRequest() {
 void PHProbe::getCalibration(char *buffer, int size) {
   // for example "?Cal,2" or "     Calib requested!"
   if (strcmp_P(calibrationResponse, PSTR("R")) == 0) {
-    strscpy_P(buffer, F("Calib requested!"), sizeof(buffer));
+    strscpy_P(buffer, F("Calib requested!"), size);
   } else {
     strscpy(buffer, calibrationResponse, size);
   }
@@ -64,7 +64,7 @@ void PHProbe::sendSlopeRequest() {
 void PHProbe::getSlope(char *buffer, int size) {
   // for example "99.7,100.3, -0.89" or "R"
   if (strcmp_P(slopeResponse, PSTR("R")) == 0) {
-    strscpy_P(buffer, F("Slope requested!"), sizeof(buffer));
+    strscpy_P(buffer, F("Slope requested!"), size);
   } else {
     strscpy(buffer, slopeResponse, size);
   }

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -56,8 +56,8 @@ void PHProbe::sendCalibrationRequest() {
   GodmodeState *state = GODMODE();
   char buffer[10];
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?Cal,%i\r"), calibrationPoints);
-  state->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
-  tc->serialEvent1();                    // fake interrupt
+  state->serialPort[1].dataIn = buffer;        // the queue of data waiting to be read
+  TankController::instance()->serialEvent1();  // fake interrupt
 #endif
   strscpy_P(calibrationResponse, F("Requesting..."), sizeof(calibrationResponse));
 }
@@ -74,8 +74,8 @@ void PHProbe::sendSlopeRequest() {
   GodmodeState *state = GODMODE();
   char buffer[10];
   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?SLOPE,99.7,100.3,-0.89\r"));
-  state->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
-  tc->serialEvent1();                    // fake interrupt
+  state->serialPort[1].dataIn = buffer;        // the queue of data waiting to be read
+  TankController::instance()->serialEvent1();  // fake interrupt
 #endif
   strscpy_P(slopeResponse, F("Requesting..."), sizeof(slopeResponse));
 }

--- a/src/Devices/PHProbe.cpp
+++ b/src/Devices/PHProbe.cpp
@@ -55,7 +55,7 @@ void PHProbe::sendCalibrationRequest() {
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
   GodmodeState *state = GODMODE();
   char buffer[10];
-  snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?Cal,%i\r"), calibrationPoints);
+  snprintf_P(buffer, sizeof(buffer), (PGM_P)F("?Cal,%i\r"), this->calibrationPoints);
   state->serialPort[1].dataIn = buffer;        // the queue of data waiting to be read
   TankController::instance()->serialEvent1();  // fake interrupt
 #endif

--- a/src/Devices/PHProbe.h
+++ b/src/Devices/PHProbe.h
@@ -41,7 +41,7 @@ private:
   static PHProbe* _instance;
   // instance variable
   float value = 0;
-  char calibrationResponse[2] = "";
+  char calibrationResponse[14] = "";
   char slopeResponse[32] = "";
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
   int calibrationPoints = 0;

--- a/src/Devices/PHProbe.h
+++ b/src/Devices/PHProbe.h
@@ -10,6 +10,7 @@
  * clear the other calibration points.
  *
  * While the data sheet uses "Slope" the actual string is "SLOPE"
+ * Similarly, "Cal,?" is actually "CAL,?" and responses are "?CAL,2" for example.
  */
 
 // getValue() function is for testing purposes

--- a/src/Devices/PHProbe.h
+++ b/src/Devices/PHProbe.h
@@ -33,6 +33,7 @@ public:
   void setMidpointCalibration(float midpoint);
   void setTemperatureCompensation(float temperature);
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
+  void setCalibrationPoints(int newValue);
   void setPh(float newValue);
 #endif
 private:
@@ -42,6 +43,9 @@ private:
   float value = 0;
   char calibrationResponse[2] = "";
   char slopeResponse[32] = "";
+#if defined(ARDUINO_CI_COMPILATION_MOCKS)
+  int calibrationPoints = 0;
+#endif
   // Methods
   PHProbe();
 };

--- a/src/Devices/PHProbe.h
+++ b/src/Devices/PHProbe.h
@@ -20,9 +20,6 @@ public:
   float getPh() {
     return value;
   }
-  const char* getSlopeResponse() const {
-    return slopeResponse;
-  }
   void clearCalibration();
   void getCalibration(char* buffer, int size);
   void getSlope(char* buffer, int size);
@@ -34,7 +31,13 @@ public:
   void setMidpointCalibration(float midpoint);
   void setTemperatureCompensation(float temperature);
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  void setCalibrationPoints(int newValue);
+  const char* getCalibrationResponse() const {
+    return calibrationResponse;
+  }
+  const char* getSlopeResponse() const {
+    return slopeResponse;
+  }
+  void setCalibration(int calibrationPoints = 0);
   void setPh(float newValue);
   void setPhSlope(const char* slope = "?SLOPE,99.7,100.3,-0.89\r");
 #endif
@@ -45,9 +48,6 @@ private:
   float value = 0;
   char calibrationResponse[14] = "";
   char slopeResponse[32] = "";
-#if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  int calibrationPoints = 0;
-#endif
   // Methods
   PHProbe();
 };

--- a/src/Devices/PHProbe.h
+++ b/src/Devices/PHProbe.h
@@ -20,10 +20,12 @@ public:
     return value;
   }
   const char* getSlopeResponse() const {
-    return slopeResponse;
+    return probeResponse;
   }
   void clearCalibration();
+  void getCalibration(char* buffer, int size);
   void getSlope(char* buffer, int size);
+  void sendCalibrationRequest();
   void sendSlopeRequest();
   void serialEvent1();
   void setHighpointCalibration(float highpoint);
@@ -38,7 +40,7 @@ private:
   static PHProbe* _instance;
   // instance variable
   float value = 0;
-  char slopeResponse[32] = "";
+  char probeResponse[32] = "";
   // Methods
   PHProbe();
 };

--- a/src/Devices/PHProbe.h
+++ b/src/Devices/PHProbe.h
@@ -20,7 +20,7 @@ public:
     return value;
   }
   const char* getSlopeResponse() const {
-    return probeResponse;
+    return slopeResponse;
   }
   void clearCalibration();
   void getCalibration(char* buffer, int size);
@@ -40,7 +40,8 @@ private:
   static PHProbe* _instance;
   // instance variable
   float value = 0;
-  char probeResponse[32] = "";
+  char calibrationResponse[2] = "";
+  char slopeResponse[32] = "";
   // Methods
   PHProbe();
 };

--- a/src/TankController.h
+++ b/src/TankController.h
@@ -31,13 +31,6 @@ public:
     nextKey = value;
   }
 
-#if defined(ARDUINO_CI_COMPILATION_MOCKS)
-  // remove:
-  UIState* returnNextState() {
-    return this->nextState;
-  }
-#endif
-
 private:
   // class variables
   static TankController* _instance;

--- a/src/TankController.h
+++ b/src/TankController.h
@@ -31,6 +31,13 @@ public:
     nextKey = value;
   }
 
+#if defined(ARDUINO_CI_COMPILATION_MOCKS)
+  // remove:
+  UIState* returnState() {
+    return this->nextState;
+  }
+#endif
+
 private:
   // class variables
   static TankController* _instance;

--- a/src/TankController.h
+++ b/src/TankController.h
@@ -33,7 +33,7 @@ public:
 
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
   // remove:
-  UIState* returnState() {
+  UIState* returnNextState() {
     return this->nextState;
   }
 #endif

--- a/src/UIState/NumberCollectorState.cpp
+++ b/src/UIState/NumberCollectorState.cpp
@@ -61,9 +61,13 @@ void NumCollectorState::printValue() {
   char format[20], strValue[20];
   // The Arduino does not support variable widths, so we construct the format string at runtime!
   char buffer[8];
-  floattostrf(getCurrentValue(), 7, getCurrentValuePrecision(), buffer, sizeof(buffer));
-  memcpy(strValue, buffer, sizeof(buffer));
-  snprintf_P(strValue + 7, 3, (PGM_P)F("->"));
+  if (this->showCurrentValue()) {
+    floattostrf(getCurrentValue(), 7, getCurrentValuePrecision(), buffer, sizeof(buffer));
+    memcpy(strValue, buffer, sizeof(buffer));
+    snprintf_P(strValue + 7, 3, (PGM_P)F("->"));
+  } else {
+    strscpy_P(strValue, F("         "), sizeof(strValue));
+  }
 
   if (!hasDecimal) {
     // show user entry as an integer (no decimal yet)

--- a/src/UIState/NumberCollectorState.h
+++ b/src/UIState/NumberCollectorState.h
@@ -87,9 +87,9 @@ public:
   }
 };
 
-class TestNoCurrentNumCollectorState : public TestNumCollectorState {
+class TestNumCollectorStateWithNoCurrentValue : public TestNumCollectorState {
 public:
-  TestNoCurrentNumCollectorState(TankController* tc) : TestNumCollectorState(tc) {
+  TestNumCollectorStateWithNoCurrentValue(TankController* tc) : TestNumCollectorState(tc) {
   }
   bool showCurrentValue() {
     return false;

--- a/src/UIState/NumberCollectorState.h
+++ b/src/UIState/NumberCollectorState.h
@@ -26,6 +26,9 @@ protected:
   virtual uint16_t getCurrentValuePrecision() {
     return 0;
   };
+  virtual bool showCurrentValue() {
+    return true;
+  }
 
   float value = 0.0;
   uint16_t numDigits = 0;
@@ -81,6 +84,15 @@ public:
   }
   virtual bool isInteger() {
     return true;
+  }
+};
+
+class TestNoCurrentNumCollectorState : public TestNumCollectorState {
+public:
+  TestNoCurrentNumCollectorState(TankController* tc) : TestNumCollectorState(tc) {
+  }
+  bool showCurrentValue() {
+    return false;
   }
 };
 

--- a/src/UIState/PHCalibration.h
+++ b/src/UIState/PHCalibration.h
@@ -10,14 +10,14 @@ public:
     return true;  // disable controls during calibration
   }
   float getCurrentValue() {
-    return PHProbe::instance()->getPh();
+    return 0;
   }
   void loop() {
     printValue();
   }
 
 protected:
-  virtual uint16_t getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() {
     return 3;
   }
   bool showCurrentValue() {

--- a/src/UIState/PHCalibration.h
+++ b/src/UIState/PHCalibration.h
@@ -20,4 +20,7 @@ protected:
   virtual uint16_t getCurrentValuePrecision() {
     return 3;
   }
+  bool showCurrentValue() {
+    return false;
+  }
 };

--- a/src/UIState/PHCalibration.h
+++ b/src/UIState/PHCalibration.h
@@ -6,21 +6,21 @@ class PHCalibration : public NumCollectorState {
 public:
   PHCalibration(TankController* tc) : NumCollectorState(tc) {
   }
-  bool isInCalibration() {
+  bool isInCalibration() override {
     return true;  // disable controls during calibration
   }
-  float getCurrentValue() {
+  float getCurrentValue() override {
     return 0;
   }
-  void loop() {
+  void loop() override {
     printValue();
   }
 
 protected:
-  uint16_t getCurrentValuePrecision() {
+  uint16_t getCurrentValuePrecision() override {
     return 3;
   }
-  bool showCurrentValue() {
+  bool showCurrentValue() override {
     return false;
   }
 };

--- a/src/UIState/PHCalibrationHigh.cpp
+++ b/src/UIState/PHCalibrationHigh.cpp
@@ -6,6 +6,7 @@
 #include "Devices/LiquidCrystal_TC.h"
 #include "Devices/PHProbe.h"
 #include "SeePHCalibration.h"
+#include "Wait.h"
 
 void PHCalibrationHigh::setValue(float value) {
   PHProbe::instance()->setHighpointCalibration(value);

--- a/src/UIState/PHCalibrationHigh.cpp
+++ b/src/UIState/PHCalibrationHigh.cpp
@@ -14,5 +14,5 @@ void PHCalibrationHigh::setValue(float value) {
   strscpy_P(buffer, F("New High="), sizeof(buffer));
   floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New High=12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-  this->setNextState((UIState*)new Wait(tc, 3000, new SeePHCalibration(tc)));
+  this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc)));
 }

--- a/src/UIState/PHCalibrationHigh.cpp
+++ b/src/UIState/PHCalibrationHigh.cpp
@@ -5,6 +5,7 @@
 
 #include "Devices/LiquidCrystal_TC.h"
 #include "Devices/PHProbe.h"
+#include "SeePHCalibration.h"
 
 void PHCalibrationHigh::setValue(float value) {
   PHProbe::instance()->setHighpointCalibration(value);
@@ -12,5 +13,5 @@ void PHCalibrationHigh::setValue(float value) {
   strscpy_P(buffer, F("New High="), sizeof(buffer));
   floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New High=12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-  returnToMainMenu(3000);
+  this->setNextState((UIState*)new Wait(tc, 3000, new SeePHCalibration(tc)));
 }

--- a/src/UIState/PHCalibrationHigh.cpp
+++ b/src/UIState/PHCalibrationHigh.cpp
@@ -14,5 +14,5 @@ void PHCalibrationHigh::setValue(float value) {
   strscpy_P(buffer, F("New High="), sizeof(buffer));
   floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New High=12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-  this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc)));
+  this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc, true)));
 }

--- a/src/UIState/PHCalibrationHigh.h
+++ b/src/UIState/PHCalibrationHigh.h
@@ -11,11 +11,11 @@ class PHCalibrationHigh : public PHCalibration {
 public:
   PHCalibrationHigh(TankController* tc) : PHCalibration(tc) {
   }
-  const __FlashStringHelper* name() {
+  const __FlashStringHelper* name() override {
     return F("PHCalibrationHigh");
   }
-  const __FlashStringHelper* prompt() {
+  const __FlashStringHelper* prompt() override {
     return F("pH-Highpoint");
   };
-  void setValue(float value);
+  void setValue(float value) override;
 };

--- a/src/UIState/PHCalibrationLow.cpp
+++ b/src/UIState/PHCalibrationLow.cpp
@@ -6,23 +6,19 @@
 #include "Devices/LiquidCrystal_TC.h"
 #include "Devices/PHProbe.h"
 #include "PHCalibrationHigh.h"
+#include "SeePHCalibration.h"
 #include "UIState.h"
 #include "Wait.h"
 
-void PHCalibrationLow::setLowValue(float value) {
+void PHCalibrationLow::setValue(float value) {
   PHProbe::instance()->setLowpointCalibration(value);
   char buffer[17];
   strscpy_P(buffer, F("New Low = "), sizeof(buffer));
   floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New Low = 12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-}
-
-void PHCalibrationLowTwo::setValue(float value) {
-  this->setLowValue(value);
-  returnToMainMenu(3000);
-}
-
-void PHCalibrationLowThree::setValue(float value) {
-  this->setLowValue(value);
-  this->setNextState((UIState*)new Wait(tc, 3000, new PHCalibrationHigh(tc)));
+  if (this->numberOfCalibrationPoints > 2) {
+    this->setNextState((UIState*)new Wait(tc, 3000, new PHCalibrationHigh(tc, this->numberOfCalibrationPoints)));
+  } else {
+    this->setNextState((UIState*)new Wait(tc, 3000, new SeePHCalibration(tc)));
+  }
 }

--- a/src/UIState/PHCalibrationLow.cpp
+++ b/src/UIState/PHCalibrationLow.cpp
@@ -19,6 +19,6 @@ void PHCalibrationLow::setValue(float value) {
   if (this->numberOfCalibrationPoints > 2) {
     this->setNextState(new Wait(tc, 3000, new PHCalibrationHigh(tc)));
   } else {
-    this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc)));
+    this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc, true)));
   }
 }

--- a/src/UIState/PHCalibrationLow.cpp
+++ b/src/UIState/PHCalibrationLow.cpp
@@ -17,7 +17,7 @@ void PHCalibrationLow::setValue(float value) {
   floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New Low = 12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
   if (this->numberOfCalibrationPoints > 2) {
-    this->setNextState((UIState*)new Wait(tc, 3000, new PHCalibrationHigh(tc, this->numberOfCalibrationPoints)));
+    this->setNextState((UIState*)new Wait(tc, 3000, new PHCalibrationHigh(tc)));
   } else {
     this->setNextState((UIState*)new Wait(tc, 3000, new SeePHCalibration(tc)));
   }

--- a/src/UIState/PHCalibrationLow.h
+++ b/src/UIState/PHCalibrationLow.h
@@ -18,8 +18,8 @@ public:
   const __FlashStringHelper* prompt() override {
     return F("pH-Lowpoint");
   };
+  void setValue(float value) override;
 
 private:
   int numberOfCalibrationPoints;
-  void setValue(float value) override;
 };

--- a/src/UIState/PHCalibrationLow.h
+++ b/src/UIState/PHCalibrationLow.h
@@ -21,5 +21,5 @@ public:
   void setValue(float value) override;
 
 private:
-  int numberOfCalibrationPoints;
+  int numberOfCalibrationPoints = 3;
 };

--- a/src/UIState/PHCalibrationLow.h
+++ b/src/UIState/PHCalibrationLow.h
@@ -9,40 +9,17 @@
 
 class PHCalibrationLow : public PHCalibration {
 public:
-  PHCalibrationLow(TankController* tc) : PHCalibration(tc) {
+  PHCalibrationLow(TankController* tc, int numberOfCalibrationPoints = 3) : PHCalibration(tc) {
+    this->numberOfCalibrationPoints = numberOfCalibrationPoints;
   }
-  const __FlashStringHelper* prompt() {
+  const __FlashStringHelper* name() override {
+    return F("PHCalibrationLow");
+  }
+  const __FlashStringHelper* prompt() override {
     return F("pH-Lowpoint");
   };
 
-protected:
-  void setLowValue(float value);
-};
-
-/**
- * @brief lowpoint for 2-point pH calibration
- *
- */
-class PHCalibrationLowTwo : public PHCalibrationLow {
-public:
-  PHCalibrationLowTwo(TankController* tc) : PHCalibrationLow(tc) {
-  }
-  const __FlashStringHelper* name() {
-    return F("PHCalibrationLowTwo");
-  }
-  void setValue(float value);
-};
-
-/**
- * @brief lowpoint for 3-point pH calibration
- *
- */
-class PHCalibrationLowThree : public PHCalibrationLow {
-public:
-  PHCalibrationLowThree(TankController* tc) : PHCalibrationLow(tc) {
-  }
-  const __FlashStringHelper* name() {
-    return F("PHCalibrationLowThree");
-  }
-  void setValue(float value);
+private:
+  int numberOfCalibrationPoints;
+  void setValue(float value) override;
 };

--- a/src/UIState/PHCalibrationLow.h
+++ b/src/UIState/PHCalibrationLow.h
@@ -14,13 +14,14 @@ public:
   const __FlashStringHelper* prompt() {
     return F("pH-Lowpoint");
   };
+
 protected:
   void setLowValue(float value);
 };
 
 /**
  * @brief lowpoint for 2-point pH calibration
- * 
+ *
  */
 class PHCalibrationLowTwo : public PHCalibrationLow {
 public:
@@ -34,7 +35,7 @@ public:
 
 /**
  * @brief lowpoint for 3-point pH calibration
- * 
+ *
  */
 class PHCalibrationLowThree : public PHCalibrationLow {
 public:

--- a/src/UIState/PHCalibrationMid.cpp
+++ b/src/UIState/PHCalibrationMid.cpp
@@ -19,6 +19,6 @@ void PHCalibrationMid::setValue(float value) {
   if (this->numberOfCalibrationPoints > 1) {
     this->setNextState(new Wait(tc, 3000, new PHCalibrationLow(tc, this->numberOfCalibrationPoints)));
   } else {
-    this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc)));
+    this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc, true)));
   }
 }

--- a/src/UIState/PHCalibrationMid.cpp
+++ b/src/UIState/PHCalibrationMid.cpp
@@ -6,28 +6,19 @@
 #include "Devices/LiquidCrystal_TC.h"
 #include "Devices/PHProbe.h"
 #include "PHCalibrationLow.h"
+#include "SeePHCalibration.h"
 #include "UIState.h"
 #include "Wait.h"
 
-void PHCalibrationMid::setMidValue(float value) {
+void PHCalibrationMid::setValue(float value) {
   PHProbe::instance()->setMidpointCalibration(value);
   char buffer[17];
   strscpy_P(buffer, F("New Mid = "), sizeof(buffer));
   floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New Mid = 12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-}
-
-void PHCalibrationMidOne::setValue(float value) {
-  this->setMidValue(value);
-  returnToMainMenu(3000);
-}
-
-void PHCalibrationMidTwo::setValue(float value) {
-  this->setMidValue(value);
-  this->setNextState((UIState*)new Wait(tc, 3000, new PHCalibrationLowTwo(tc)));
-}
-
-void PHCalibrationMidThree::setValue(float value) {
-  this->setMidValue(value);
-  this->setNextState((UIState*)new Wait(tc, 3000, new PHCalibrationLowThree(tc)));
+  if (this->numberOfCalibrationPoints > 1) {
+    this->setNextState((UIState*)new Wait(tc, 3000, new PHCalibrationLow(tc, this->numberOfCalibrationPoints)));
+  } else {
+    this->setNextState((UIState*)new Wait(tc, 3000, new SeePHCalibration(tc)));
+  }
 }

--- a/src/UIState/PHCalibrationMid.h
+++ b/src/UIState/PHCalibrationMid.h
@@ -21,5 +21,5 @@ public:
   void setValue(float value) override;
 
 private:
-  int numberOfCalibrationPoints;
+  int numberOfCalibrationPoints = 3;
 };

--- a/src/UIState/PHCalibrationMid.h
+++ b/src/UIState/PHCalibrationMid.h
@@ -18,8 +18,8 @@ public:
   const __FlashStringHelper* prompt() override {
     return F("pH-Midpoint");
   };
+  void setValue(float value) override;
 
 private:
   int numberOfCalibrationPoints;
-  void setValue(float value) override;
 };

--- a/src/UIState/PHCalibrationMid.h
+++ b/src/UIState/PHCalibrationMid.h
@@ -9,54 +9,17 @@
 
 class PHCalibrationMid : public PHCalibration {
 public:
-  PHCalibrationMid(TankController* tc) : PHCalibration(tc) {
+  PHCalibrationMid(TankController* tc, int numberOfCalibrationPoints = 3) : PHCalibration(tc) {
+    this->numberOfCalibrationPoints = numberOfCalibrationPoints;
   }
-  const __FlashStringHelper* prompt() {
+  const __FlashStringHelper* name() override {
+    return F("PHCalibrationMid");
+  }
+  const __FlashStringHelper* prompt() override {
     return F("pH-Midpoint");
   };
 
-protected:
-  void setMidValue(float value);
-};
-
-/**
- * @brief midpoint for 1-point pH calibration
- *
- */
-class PHCalibrationMidOne : public PHCalibrationMid {
-public:
-  PHCalibrationMidOne(TankController* tc) : PHCalibrationMid(tc) {
-  }
-  const __FlashStringHelper* name() {
-    return F("PHCalibrationMidOne");
-  }
-  void setValue(float value);
-};
-
-/**
- * @brief midpoint for 2-point pH calibration
- *
- */
-class PHCalibrationMidTwo : public PHCalibrationMid {
-public:
-  PHCalibrationMidTwo(TankController* tc) : PHCalibrationMid(tc) {
-  }
-  const __FlashStringHelper* name() {
-    return F("PHCalibrationMidTwo");
-  }
-  void setValue(float value);
-};
-
-/**
- * @brief midpoint for 3-point pH calibration
- *
- */
-class PHCalibrationMidThree : public PHCalibrationMid {
-public:
-  PHCalibrationMidThree(TankController* tc) : PHCalibrationMid(tc) {
-  }
-  const __FlashStringHelper* name() {
-    return F("PHCalibrationMidThree");
-  }
-  void setValue(float value);
+private:
+  int numberOfCalibrationPoints;
+  void setValue(float value) override;
 };

--- a/src/UIState/PHCalibrationMid.h
+++ b/src/UIState/PHCalibrationMid.h
@@ -14,13 +14,14 @@ public:
   const __FlashStringHelper* prompt() {
     return F("pH-Midpoint");
   };
+
 protected:
   void setMidValue(float value);
 };
 
 /**
  * @brief midpoint for 1-point pH calibration
- * 
+ *
  */
 class PHCalibrationMidOne : public PHCalibrationMid {
 public:
@@ -34,7 +35,7 @@ public:
 
 /**
  * @brief midpoint for 2-point pH calibration
- * 
+ *
  */
 class PHCalibrationMidTwo : public PHCalibrationMid {
 public:
@@ -48,7 +49,7 @@ public:
 
 /**
  * @brief midpoint for 3-point pH calibration
- * 
+ *
  */
 class PHCalibrationMidThree : public PHCalibrationMid {
 public:

--- a/src/UIState/PHCalibrationPrompt.cpp
+++ b/src/UIState/PHCalibrationPrompt.cpp
@@ -19,6 +19,6 @@ void PHCalibrationPrompt::setValue(float value) {
   } else {
     strscpy_P(buffer, F("Invalid entry"), sizeof(buffer));
     LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-    this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc)));
+    this->setNextState(new Wait(tc, 3000));
   }
 }

--- a/src/UIState/PHCalibrationPrompt.cpp
+++ b/src/UIState/PHCalibrationPrompt.cpp
@@ -6,26 +6,19 @@
 #include "Devices/LiquidCrystal_TC.h"
 #include "Devices/PHProbe.h"
 #include "PHCalibrationMid.h"
+#include "SeePHCalibration.h"
 #include "UIState.h"
 #include "Wait.h"
 
 void PHCalibrationPrompt::setValue(float value) {
   char buffer[17];
-  if (value == 1) {
-    strscpy_P(buffer, F("1-pt pH calib..."), sizeof(buffer));
+  if (value == 1 || value == 2 || value == 3) {
+    snprintf_P(buffer, sizeof(buffer, F("%i-pt pH calib..."), value);
     LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-    this->setNextState((UIState*)new Wait(tc, 2000, new PHCalibrationMidOne(tc)));
-  } else if (value == 2) {
-    strscpy_P(buffer, F("2-pt pH calib..."), sizeof(buffer));
-    LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-    this->setNextState((UIState*)new Wait(tc, 2000, new PHCalibrationMidTwo(tc)));
-  } else if (value == 3) {
-    strscpy_P(buffer, F("3-pt pH calib..."), sizeof(buffer));
-    LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-    this->setNextState((UIState*)new Wait(tc, 2000, new PHCalibrationMidThree(tc)));
+    this->setNextState((UIState*)new Wait(tc, 2000, new PHCalibrationMid(tc, value)));
   } else {
     strscpy_P(buffer, F("Invalid entry"), sizeof(buffer));
     LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-    returnToMainMenu(3000);
+    this->setNextState((UIState*)new Wait(tc, 3000, new SeePHCalibration(tc)));
   }
 }

--- a/src/UIState/PHCalibrationPrompt.cpp
+++ b/src/UIState/PHCalibrationPrompt.cpp
@@ -15,10 +15,10 @@ void PHCalibrationPrompt::setValue(float value) {
   if (value == 1 || value == 2 || value == 3) {
     snprintf_P(buffer, sizeof(buffer), PSTR("%i-pt pH calib..."), (int)value);
     LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-    this->setNextState((UIState*)new Wait(tc, 2000, new PHCalibrationMid(tc, value)));
+    this->setNextState(new Wait(tc, 2000, new PHCalibrationMid(tc, value)));
   } else {
     strscpy_P(buffer, F("Invalid entry"), sizeof(buffer));
     LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-    this->setNextState((UIState*)new Wait(tc, 3000, new SeePHCalibration(tc)));
+    this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc)));
   }
 }

--- a/src/UIState/PHCalibrationPrompt.cpp
+++ b/src/UIState/PHCalibrationPrompt.cpp
@@ -13,7 +13,7 @@
 void PHCalibrationPrompt::setValue(float value) {
   char buffer[17];
   if (value == 1 || value == 2 || value == 3) {
-    snprintf_P(buffer, sizeof(buffer, F("%i-pt pH calib..."), value);
+    snprintf_P(buffer, sizeof(buffer), PSTR("%i-pt pH calib..."), (int)value);
     LiquidCrystal_TC::instance()->writeLine(buffer, 1);
     this->setNextState((UIState*)new Wait(tc, 2000, new PHCalibrationMid(tc, value)));
   } else {

--- a/src/UIState/PHCalibrationPrompt.h
+++ b/src/UIState/PHCalibrationPrompt.h
@@ -20,9 +20,6 @@ public:
   void setValue(float value);
 
 protected:
-  uint16_t getCurrentValuePrecision() {
-    return 0;
-  }
   bool isInteger() {
     return true;
   }

--- a/src/UIState/PHCalibrationPrompt.h
+++ b/src/UIState/PHCalibrationPrompt.h
@@ -11,16 +11,16 @@ class PHCalibrationPrompt : public PHCalibration {
 public:
   PHCalibrationPrompt(TankController* tc) : PHCalibration(tc) {
   }
-  const __FlashStringHelper* name() {
+  const __FlashStringHelper* name() override {
     return F("PHCalibrationPrompt");
   }
-  const __FlashStringHelper* prompt() {
+  const __FlashStringHelper* prompt() override {
     return F("1, 2 or 3 point?");
   };
-  void setValue(float value);
+  void setValue(float value) override;
 
-protected:
-  bool isInteger() {
+private:
+  bool isInteger() override {
     return true;
   }
 };

--- a/src/UIState/SeePHCalibration.cpp
+++ b/src/UIState/SeePHCalibration.cpp
@@ -1,0 +1,20 @@
+/**
+ * SeePHCalibration.cpp
+ */
+
+#include "SeePHCalibration.h"
+
+#include "Devices/LiquidCrystal_TC.h"
+#include "Devices/PHProbe.h"
+
+void SeePHCalibration::loop() {
+  char buffer[20];
+  PHProbe::instance()->getCalibration(buffer, sizeof(buffer));
+  LiquidCrystal_TC::instance()->writeLine(buffer, 1);
+}
+
+void SeePHCalibration::start() {
+  LiquidCrystal_TC::instance()->writeLine(prompt(), 0);
+  LiquidCrystal_TC::instance()->writeLine(F("requesting calib"), 1);
+  PHProbe::instance()->sendCalibrationRequest();
+}

--- a/src/UIState/SeePHCalibration.h
+++ b/src/UIState/SeePHCalibration.h
@@ -1,0 +1,21 @@
+/**
+ * SeePHCalibration.h
+ *
+ * Display the pH calibration
+ */
+#pragma once
+#include "UIState.h"
+
+class SeePHCalibration : public UIState {
+public:
+  SeePHCalibration(TankController* tc) : UIState(tc) {
+  }
+  void start() override;
+  void loop() override;
+  const __FlashStringHelper* name() override {
+    return F("SeePHCalibration");
+  }
+  const __FlashStringHelper* prompt() override {
+    return F("PH Calibration:");
+  };
+};

--- a/src/UIState/SeePHCalibration.h
+++ b/src/UIState/SeePHCalibration.h
@@ -8,10 +8,11 @@
 
 class SeePHCalibration : public UIState {
 public:
-  SeePHCalibration(TankController* tc) : UIState(tc) {
+  SeePHCalibration(TankController* tc, bool inCalibration = false) : UIState(tc) {
+    this->inCalibration = inCalibration;
   }
   bool isInCalibration() override {
-    return true;
+    return inCalibration;
   }
   void loop() override;
   void start() override;
@@ -21,4 +22,7 @@ public:
   const __FlashStringHelper* prompt() override {
     return F("PH Calibration:");
   };
+
+private:
+  bool inCalibration;
 };

--- a/src/UIState/SeePHCalibration.h
+++ b/src/UIState/SeePHCalibration.h
@@ -10,8 +10,11 @@ class SeePHCalibration : public UIState {
 public:
   SeePHCalibration(TankController* tc) : UIState(tc) {
   }
-  void start() override;
+  bool isInCalibration() override {
+    return true;
+  }
   void loop() override;
+  void start() override;
   const __FlashStringHelper* name() override {
     return F("SeePHCalibration");
   }

--- a/src/UIState/SeePHSlope.h
+++ b/src/UIState/SeePHSlope.h
@@ -1,7 +1,7 @@
 /**
  * SeePHSlope.h
  *
- * Display the tank ID
+ * Display the pH slope
  */
 #pragma once
 #include "UIState.h"

--- a/src/UIState/SetPHCalibClear.cpp
+++ b/src/UIState/SetPHCalibClear.cpp
@@ -12,7 +12,7 @@ void SetPHCalibClear::handleKey(char key) {
   switch (key) {
     case 'A':  // Save (clear calibration)
       PHProbe::instance()->clearCalibration();
-      this->setNextState(new SeePHCalibration(tc));
+      this->setNextState(new SeePHCalibration(tc, false));
       break;
     case 'D':  // Don't save (cancel)
       returnToMainMenu();

--- a/src/UIState/TemperatureCalibration.h
+++ b/src/UIState/TemperatureCalibration.h
@@ -26,4 +26,7 @@ public:
     return F("Real Temperature");
   };
   void setValue(float value);
+  bool showCurrentValue() {
+    return false;
+  }
 };

--- a/src/UIState/Wait.cpp
+++ b/src/UIState/Wait.cpp
@@ -32,6 +32,13 @@ Wait::~Wait() {
   }
 }
 
+bool Wait::isInCalibration() {
+  if (nextState) {
+    return nextState->isInCalibration();
+  }
+  return false;
+}
+
 void Wait::loop() {
   if (endTime <= millis()) {
     this->setNextState(nextState);

--- a/src/UIState/Wait.cpp
+++ b/src/UIState/Wait.cpp
@@ -35,6 +35,6 @@ Wait::~Wait() {
 void Wait::loop() {
   if (endTime <= millis()) {
     this->setNextState(nextState);
-    nextState = nullptr
+    nextState = nullptr;  // otherwise ~Wait() will destroy an active state
   }
 }

--- a/src/UIState/Wait.cpp
+++ b/src/UIState/Wait.cpp
@@ -6,9 +6,9 @@
 /**
  * @brief Construct a new Wait:: Wait object
  *
- * @param tc 
- * @param msDelay 
- * @param nextState 
+ * @param tc
+ * @param msDelay
+ * @param nextState
  */
 Wait::Wait(TankController *tc, uint16_t msDelay, UIState *nextState) : UIState(tc) {
   endTime = millis() + msDelay;

--- a/src/UIState/Wait.cpp
+++ b/src/UIState/Wait.cpp
@@ -42,6 +42,6 @@ bool Wait::isInCalibration() {
 void Wait::loop() {
   if (endTime <= millis()) {
     this->setNextState(nextState);
-    nextState = nullptr;  // otherwise ~Wait() will destroy an active state
+    nextState = nullptr;  // otherwise ~Wait() will destroy the active state
   }
 }

--- a/src/UIState/Wait.cpp
+++ b/src/UIState/Wait.cpp
@@ -35,5 +35,6 @@ Wait::~Wait() {
 void Wait::loop() {
   if (endTime <= millis()) {
     this->setNextState(nextState);
+    nextState = nullptr
   }
 }

--- a/src/UIState/Wait.cpp
+++ b/src/UIState/Wait.cpp
@@ -3,6 +3,13 @@
 #include "MainMenu.h"
 #include "TC_util.h"
 
+/**
+ * @brief Construct a new Wait:: Wait object
+ *
+ * @param tc 
+ * @param msDelay 
+ * @param nextState 
+ */
 Wait::Wait(TankController *tc, uint16_t msDelay, UIState *nextState) : UIState(tc) {
   endTime = millis() + msDelay;
   if (nextState) {
@@ -11,6 +18,17 @@ Wait::Wait(TankController *tc, uint16_t msDelay, UIState *nextState) : UIState(t
   this->nextState = nextState;
   if (this->nextState == nullptr) {
     this->nextState = (UIState *)new MainMenu(tc);
+  }
+}
+
+/**
+ * @brief Destroy the Wait:: Wait object
+ *
+ */
+Wait::~Wait() {
+  if (nextState) {
+    delete nextState;
+    nextState = nullptr;
   }
 }
 

--- a/src/UIState/Wait.h
+++ b/src/UIState/Wait.h
@@ -10,7 +10,7 @@ class Wait : public UIState {
 public:
   Wait(TankController* tc, uint16_t msDelay = 1000, UIState* nextState = nullptr);
   bool isInCalibration() {
-    return nextState->isInCalibration();
+    return this->nextState->isInCalibration();
   }
   // watch to see if enough time has passed
   void loop();

--- a/src/UIState/Wait.h
+++ b/src/UIState/Wait.h
@@ -9,16 +9,16 @@
 class Wait : public UIState {
 public:
   Wait(TankController* tc, uint16_t msDelay = 1000, UIState* nextState = nullptr);
-  bool isInCalibration() {
-    return this->nextState->isInCalibration();
-  }
+  // bool isInCalibration() {
+  //   return nextState->isInCalibration();
+  // }
   // watch to see if enough time has passed
-  void loop();
-  const __FlashStringHelper* name() {
+  void loop() override;
+  const __FlashStringHelper* name() override {
     return F("Wait");
   }
   // override to do nothing
-  void start() {
+  void start() override {
   }
 
 private:

--- a/src/UIState/Wait.h
+++ b/src/UIState/Wait.h
@@ -9,6 +9,9 @@
 class Wait : public UIState {
 public:
   Wait(TankController* tc, uint16_t msDelay = 1000, UIState* nextState = nullptr);
+  bool isInCalibration() {
+    return nextState->isInCalibration();
+  }
   // watch to see if enough time has passed
   void loop();
   const __FlashStringHelper* name() {

--- a/src/UIState/Wait.h
+++ b/src/UIState/Wait.h
@@ -9,9 +9,9 @@
 class Wait : public UIState {
 public:
   Wait(TankController* tc, uint16_t msDelay = 1000, UIState* nextState = nullptr);
-  // bool isInCalibration() {
-  //   return nextState->isInCalibration();
-  // }
+  bool isInCalibration() {
+    return nextState->isInCalibration();
+  }
   // watch to see if enough time has passed
   void loop() override;
   const __FlashStringHelper* name() override {
@@ -22,6 +22,10 @@ public:
   }
 
 private:
+  // instance variables
   uint32_t endTime = 0;
   UIState* nextState = nullptr;
+
+  // instance methods
+  ~Wait();
 };

--- a/src/UIState/Wait.h
+++ b/src/UIState/Wait.h
@@ -9,9 +9,7 @@
 class Wait : public UIState {
 public:
   Wait(TankController* tc, uint16_t msDelay = 1000, UIState* nextState = nullptr);
-  bool isInCalibration() {
-    return nextState->isInCalibration();
-  }
+  bool isInCalibration();
   // watch to see if enough time has passed
   void loop() override;
   const __FlashStringHelper* name() override {

--- a/test/MenuTest.cpp
+++ b/test/MenuTest.cpp
@@ -8,7 +8,7 @@
 #include "Keypad_TC.h"
 #include "LiquidCrystal_TC.h"
 #include "MainMenu.h"
-#include "PHCalibrationHigh.h"
+#include "PHCalibrationPrompt.h"
 #include "TankController.h"
 #include "TempProbe_TC.h"
 

--- a/test/NumberCollectorStateTest.cpp
+++ b/test/NumberCollectorStateTest.cpp
@@ -139,7 +139,7 @@ unittest(printing) {
 unittest(printingNoCurrent) {
   LiquidCrystal_TC* testLcd = LiquidCrystal_TC::instance();
   std::vector<String> lines;
-  TestNoCurrentNumCollectorState test(TankController::instance());
+  TestNumCollectorStateWithNoCurrentValue test(TankController::instance());
   test.start();
   lines = testLcd->getLines();
   assertEqual("              0 ", lines.at(1));

--- a/test/NumberCollectorStateTest.cpp
+++ b/test/NumberCollectorStateTest.cpp
@@ -136,6 +136,43 @@ unittest(printing) {
   assertEqual(" 34.125-> 21.341", lines.at(1));
 }
 
+unittest(printingNoCurrent) {
+  LiquidCrystal_TC* testLcd = LiquidCrystal_TC::instance();
+  std::vector<String> lines;
+  TestNoCurrentNumCollectorState test(TankController::instance());
+  test.start();
+  lines = testLcd->getLines();
+  assertEqual("              0 ", lines.at(1));
+
+  test.setPriorValue(34.125);
+  test.setPriorValuePrecision(1);
+  test.handleKey('2');
+  lines = testLcd->getLines();
+  assertEqual("              2 ", lines.at(1));
+
+  test.handleKey('1');
+  lines = testLcd->getLines();
+  assertEqual("             21 ", lines.at(1));
+
+  test.handleKey('*');
+  lines = testLcd->getLines();
+  assertEqual("             21.", lines.at(1));
+
+  test.handleKey('3');
+  lines = testLcd->getLines();
+  assertEqual("            21.3", lines.at(1));
+
+  test.setPriorValuePrecision(2);
+  test.handleKey('4');
+  lines = testLcd->getLines();
+  assertEqual("           21.34", lines.at(1));
+
+  test.setPriorValuePrecision(3);
+  test.handleKey('1');
+  lines = testLcd->getLines();
+  assertEqual("          21.341", lines.at(1));
+}
+
 unittest(integer) {
   TestIntNumCollectorState testDecimal(TankController::instance());
   testDecimal.handleKey('1');

--- a/test/PHCalibrationHighTest.cpp
+++ b/test/PHCalibrationHighTest.cpp
@@ -20,9 +20,9 @@ unittest(test) {
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(3000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to MainMenu
-  tc->loop(false);  // updateState to MainMenu
-  assertEqual("MainMenu", tc->stateName());
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
+  tc->loop(false);  // updateState to SeePHCalibration
+  assertEqual("SeePHCalibration", tc->stateName());
 }
 
 unittest_main()

--- a/test/PHCalibrationHighTest.cpp
+++ b/test/PHCalibrationHighTest.cpp
@@ -23,6 +23,7 @@ unittest(test) {
   tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
   tc->loop(false);  // updateState to SeePHCalibration
   assertEqual("SeePHCalibration", tc->stateName());
+  assertTrue(tc->isInCalibration());
 }
 
 unittest_main()

--- a/test/PHCalibrationLowTest.cpp
+++ b/test/PHCalibrationLowTest.cpp
@@ -7,7 +7,7 @@
 
 unittest(twoPointLow) {
   TankController* tc = TankController::instance();
-  PHCalibrationLowTwo* test = new PHCalibrationLowTwo(tc);
+  PHCalibrationLow* test = new PHCalibrationLow(tc, 2);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // setValue
@@ -15,18 +15,18 @@ unittest(twoPointLow) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("New Low = 12.345", lines[1]);
-  assertEqual("PHCalibrationLowTwo", tc->stateName());
+  assertEqual("PHCalibrationLow", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(3000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to MainMenu
-  tc->loop(false);  // updateState to MainMenu
-  assertEqual("MainMenu", tc->stateName());
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
+  tc->loop(false);  // updateState to SeePHCalibration
+  assertEqual("SeePHCalibration", tc->stateName());
 }
 
 unittest(threePointLow) {
   TankController* tc = TankController::instance();
-  PHCalibrationLowThree* test = new PHCalibrationLowThree(tc);
+  PHCalibrationLow* test = new PHCalibrationLow(tc, 3);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // setValue
@@ -34,7 +34,7 @@ unittest(threePointLow) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("New Low = 12.345", lines[1]);
-  assertEqual("PHCalibrationLowThree", tc->stateName());
+  assertEqual("PHCalibrationLow", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(3000);

--- a/test/PHCalibrationLowTest.cpp
+++ b/test/PHCalibrationLowTest.cpp
@@ -22,6 +22,7 @@ unittest(twoPointLow) {
   tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
   tc->loop(false);  // updateState to SeePHCalibration
   assertEqual("SeePHCalibration", tc->stateName());
+  assertTrue(tc->isInCalibration());
 }
 
 unittest(threePointLow) {
@@ -41,6 +42,7 @@ unittest(threePointLow) {
   tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationHigh
   tc->loop(false);  // updateState to PHCalibrationHigh
   assertEqual("PHCalibrationHigh", tc->stateName());
+  assertTrue(tc->isInCalibration());
 }
 
 unittest_main()

--- a/test/PHCalibrationMidTest.cpp
+++ b/test/PHCalibrationMidTest.cpp
@@ -20,14 +20,14 @@ unittest(onePointMid) {
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("  7.125->     0 ", lines.at(1));
+  assertEqual("              0 ", lines.at(1));
   GODMODE()->serialPort[1].dataIn = "7.325\r";  // the queue of data waiting to be read
   tc->serialEvent1();                           // fake interrupt
   lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("  7.125->     0 ", lines.at(1));
+  assertEqual("              0 ", lines.at(1));
   tc->loop(false);
   lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("  7.325->     0 ", lines.at(1));
+  assertEqual("              0 ", lines.at(1));
   // setValue
   test->setValue(12.345);
   // during the delay we showed the new value
@@ -57,14 +57,14 @@ unittest(twoPointMid) {
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("  7.125->     0 ", lines.at(1));
+  assertEqual("              0 ", lines.at(1));
   GODMODE()->serialPort[1].dataIn = "7.325\r";  // the queue of data waiting to be read
   tc->serialEvent1();                           // fake interrupt
   lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("  7.125->     0 ", lines.at(1));
+  assertEqual("              0 ", lines.at(1));
   tc->loop(false);
   lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("  7.325->     0 ", lines.at(1));
+  assertEqual("              0 ", lines.at(1));
   // setValue
   test->setValue(12.345);
   // during the delay we showed the new value
@@ -94,14 +94,14 @@ unittest(threePointMid) {
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("  7.125->     0 ", lines.at(1));
+  assertEqual("              0 ", lines.at(1));
   GODMODE()->serialPort[1].dataIn = "7.325\r";  // the queue of data waiting to be read
   tc->serialEvent1();                           // fake interrupt
   lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("  7.125->     0 ", lines.at(1));
+  assertEqual("              0 ", lines.at(1));
   tc->loop(false);
   lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("  7.325->     0 ", lines.at(1));
+  assertEqual("              0 ", lines.at(1));
   // setValue
   test->setValue(12.345);
   // during the delay we showed the new value

--- a/test/PHCalibrationMidTest.cpp
+++ b/test/PHCalibrationMidTest.cpp
@@ -7,10 +7,9 @@
 #include "TankController.h"
 
 unittest(onePointMid) {
-  GodmodeState *state = GODMODE();
   TankController *tc = TankController::instance();
-  state->reset();
   PHProbe *pPHProbe = PHProbe::instance();
+  GODMODE()->reset();
   pPHProbe->setPh(7.125);
   float pH = pPHProbe->getPh();
   assertEqual(7.125, pH);
@@ -42,10 +41,9 @@ unittest(onePointMid) {
 }
 
 unittest(twoPointMid) {
-  GodmodeState *state = GODMODE();
   TankController *tc = TankController::instance();
-  state->reset();
   PHProbe *pPHProbe = PHProbe::instance();
+  GODMODE()->reset();
   pPHProbe->setPh(7.125);
   float pH = pPHProbe->getPh();
   assertEqual(7.125, pH);

--- a/test/PHCalibrationMidTest.cpp
+++ b/test/PHCalibrationMidTest.cpp
@@ -9,20 +9,18 @@ unittest(onePointMid) {
   GodmodeState *state = GODMODE();
   TankController *tc = TankController::instance();
   state->reset();
-  GODMODE()->serialPort[1].dataIn = "7.125\r";  // the queue of data waiting to be read
-  tc->serialEvent1();                           // fake interrupt
   PHProbe *pPHProbe = PHProbe::instance();
+  pPHProbe->setPh(7.125);
   float pH = pPHProbe->getPh();
   assertEqual(7.125, pH);
 
   std::vector<String> lines;
-  PHCalibrationMidOne *test = new PHCalibrationMidOne(tc);
+  PHCalibrationMid *test = new PHCalibrationMid(tc, 1);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("              0 ", lines.at(1));
-  GODMODE()->serialPort[1].dataIn = "7.325\r";  // the queue of data waiting to be read
-  tc->serialEvent1();                           // fake interrupt
+  pPHProbe->setPh(7.325);
   lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("              0 ", lines.at(1));
   tc->loop(false);
@@ -33,33 +31,31 @@ unittest(onePointMid) {
   // during the delay we showed the new value
   lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("New Mid = 12.345", lines.at(1));
-  assertEqual("PHCalibrationMidOne", tc->stateName());
+  assertEqual("PHCalibrationMid", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(3000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to MainMenu
-  tc->loop(false);  // updateState to MainMenu
-  assertEqual("MainMenu", tc->stateName());
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
+  tc->loop(false);  // updateState to SeePHCalibration
+  assertEqual("SeePHCalibration", tc->stateName());
 }
 
 unittest(twoPointMid) {
   GodmodeState *state = GODMODE();
   TankController *tc = TankController::instance();
   state->reset();
-  GODMODE()->serialPort[1].dataIn = "7.125\r";  // the queue of data waiting to be read
-  tc->serialEvent1();                           // fake interrupt
   PHProbe *pPHProbe = PHProbe::instance();
+  pPHProbe->setPh(7.125);
   float pH = pPHProbe->getPh();
   assertEqual(7.125, pH);
 
   std::vector<String> lines;
-  PHCalibrationMidTwo *test = new PHCalibrationMidTwo(tc);
+  PHCalibrationMid *test = new PHCalibrationMid(tc, 2);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("              0 ", lines.at(1));
-  GODMODE()->serialPort[1].dataIn = "7.325\r";  // the queue of data waiting to be read
-  tc->serialEvent1();                           // fake interrupt
+  pPHProbe->setPh(7.325);
   lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("              0 ", lines.at(1));
   tc->loop(false);
@@ -70,50 +66,13 @@ unittest(twoPointMid) {
   // during the delay we showed the new value
   lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("New Mid = 12.345", lines.at(1));
-  assertEqual("PHCalibrationMidTwo", tc->stateName());
+  assertEqual("PHCalibrationMid", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(3000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationLowTwo
-  tc->loop(false);  // updateState to PHCalibrationLowTwo
-  assertEqual("PHCalibrationLowTwo", tc->stateName());
-}
-
-unittest(threePointMid) {
-  GodmodeState *state = GODMODE();
-  TankController *tc = TankController::instance();
-  state->reset();
-  GODMODE()->serialPort[1].dataIn = "7.125\r";  // the queue of data waiting to be read
-  tc->serialEvent1();                           // fake interrupt
-  PHProbe *pPHProbe = PHProbe::instance();
-  float pH = pPHProbe->getPh();
-  assertEqual(7.125, pH);
-
-  std::vector<String> lines;
-  PHCalibrationMidThree *test = new PHCalibrationMidThree(tc);
-  tc->setNextState(test, true);
-  assertTrue(tc->isInCalibration());
-  lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("              0 ", lines.at(1));
-  GODMODE()->serialPort[1].dataIn = "7.325\r";  // the queue of data waiting to be read
-  tc->serialEvent1();                           // fake interrupt
-  lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("              0 ", lines.at(1));
-  tc->loop(false);
-  lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("              0 ", lines.at(1));
-  // setValue
-  test->setValue(12.345);
-  // during the delay we showed the new value
-  lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("New Mid = 12.345", lines.at(1));
-  assertEqual("PHCalibrationMidThree", tc->stateName());
-  tc->loop(false);  // transition to Wait
-  assertEqual("Wait", tc->stateName());
-  delay(3000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationLowThree
-  tc->loop(false);  // updateState to PHCalibrationLowThree
-  assertEqual("PHCalibrationLowThree", tc->stateName());
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationLow
+  tc->loop(false);  // updateState to PHCalibrationLow
+  assertEqual("PHCalibrationLow", tc->stateName());
 }
 
 unittest_main()

--- a/test/PHCalibrationMidTest.cpp
+++ b/test/PHCalibrationMidTest.cpp
@@ -38,6 +38,7 @@ unittest(onePointMid) {
   tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
   tc->loop(false);  // updateState to SeePHCalibration
   assertEqual("SeePHCalibration", tc->stateName());
+  assertTrue(tc->isInCalibration());
 }
 
 unittest(twoPointMid) {
@@ -72,6 +73,7 @@ unittest(twoPointMid) {
   tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationLow
   tc->loop(false);  // updateState to PHCalibrationLow
   assertEqual("PHCalibrationLow", tc->stateName());
+  assertTrue(tc->isInCalibration());
 }
 
 unittest_main()

--- a/test/PHCalibrationPrompt.cpp
+++ b/test/PHCalibrationPrompt.cpp
@@ -76,14 +76,14 @@ unittest(badEntry) {
   // during the delay we showed feedback
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("1, 2 or 3 point?", lines[0]);
-  assertEqual("Invalid entry", lines[1]);
+  assertEqual("Invalid entry   ", lines[1]);
   assertEqual("PHCalibrationPrompt", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(2000);
   tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to MainMenu
   tc->loop(false);  // updateState to MainMenu
-  assertEqual("PHCalibrationMainMenu", tc->stateName());
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest_main()

--- a/test/PHCalibrationPrompt.cpp
+++ b/test/PHCalibrationPrompt.cpp
@@ -1,8 +1,9 @@
+#include "PHCalibrationPrompt.h"
+
 #include <Arduino.h>
 #include <ArduinoUnitTests.h>
 
 #include "Devices/LiquidCrystal_TC.h"
-#include "PHCalibrationLow.h"
 #include "TankController.h"
 
 unittest(onePoint) {

--- a/test/PHCalibrationPrompt.cpp
+++ b/test/PHCalibrationPrompt.cpp
@@ -15,8 +15,8 @@ unittest(onePoint) {
   test->setValue(1);
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("1, 2 or 3 point?", lines[1]);
-  assertEqual("1-pt pH calib...", lines[2]);
+  assertEqual("1, 2 or 3 point?", lines[0]);
+  assertEqual("1-pt pH calib...", lines[1]);
   assertEqual("PHCalibrationPrompt", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
@@ -35,8 +35,8 @@ unittest(twoPoints) {
   test->setValue(2);
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("1, 2 or 3 point?", lines[1]);
-  assertEqual("2-pt pH calib...", lines[2]);
+  assertEqual("1, 2 or 3 point?", lines[0]);
+  assertEqual("2-pt pH calib...", lines[1]);
   assertEqual("PHCalibrationPrompt", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
@@ -55,8 +55,8 @@ unittest(threePoints) {
   test->setValue(3);
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("1, 2 or 3 point?", lines[1]);
-  assertEqual("3-pt pH calib...", lines[2]);
+  assertEqual("1, 2 or 3 point?", lines[0]);
+  assertEqual("3-pt pH calib...", lines[1]);
   assertEqual("PHCalibrationPrompt", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
@@ -75,8 +75,8 @@ unittest(badEntry) {
   test->setValue(4);
   // during the delay we showed feedback
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("1, 2 or 3 point?", lines[1]);
-  assertEqual("Invalid entry", lines[2]);
+  assertEqual("1, 2 or 3 point?", lines[0]);
+  assertEqual("Invalid entry", lines[1]);
   assertEqual("PHCalibrationPrompt", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());

--- a/test/PHCalibrationPromptTest.cpp
+++ b/test/PHCalibrationPromptTest.cpp
@@ -64,9 +64,9 @@ unittest(badEntry) {
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(3000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
-  tc->loop(false);  // updateState to SeePHCalibration
-  assertEqual("SeePHCalibration", tc->stateName());
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to MainMenu
+  tc->loop(false);  // updateState to MainMenu
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest_main()

--- a/test/PHCalibrationPromptTest.cpp
+++ b/test/PHCalibrationPromptTest.cpp
@@ -1,9 +1,8 @@
-#include "PHCalibrationPrompt.h"
-
 #include <Arduino.h>
 #include <ArduinoUnitTests.h>
 
 #include "Devices/LiquidCrystal_TC.h"
+#include "PHCalibrationPrompt.h"
 #include "TankController.h"
 
 unittest(onePoint) {
@@ -80,7 +79,7 @@ unittest(badEntry) {
   assertEqual("PHCalibrationPrompt", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
-  delay(2000);
+  delay(3000);
   tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to MainMenu
   tc->loop(false);  // updateState to MainMenu
   assertEqual("MainMenu", tc->stateName());

--- a/test/PHCalibrationPromptTest.cpp
+++ b/test/PHCalibrationPromptTest.cpp
@@ -19,13 +19,15 @@ unittest(onePoint) {
   assertEqual("PHCalibrationPrompt", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
-  delay(2000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationMidOne
-  tc->loop(false);  // updateState to PHCalibrationMidOne
-  assertEqual("PHCalibrationMidOne", tc->stateName());
+  delay(1000);
+  assertTrue(tc->isInCalibration());
+  delay(1000);
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationMid
+  tc->loop(false);  // updateState to PHCalibrationMid
+  assertEqual("PHCalibrationMid", tc->stateName());
 }
 
-unittest(twoPoints) {
+unittest(twoPoint) {
   TankController* tc = TankController::instance();
   PHCalibrationPrompt* test = new PHCalibrationPrompt(tc);
   tc->setNextState(test, true);
@@ -39,30 +41,12 @@ unittest(twoPoints) {
   assertEqual("PHCalibrationPrompt", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
-  delay(2000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationMidTwo
-  tc->loop(false);  // updateState to PHCalibrationMidTwo
-  assertEqual("PHCalibrationMidTwo", tc->stateName());
-}
-
-unittest(threePoints) {
-  TankController* tc = TankController::instance();
-  PHCalibrationPrompt* test = new PHCalibrationPrompt(tc);
-  tc->setNextState(test, true);
+  delay(1000);
   assertTrue(tc->isInCalibration());
-  // setValue
-  test->setValue(3);
-  // during the delay we showed the new value
-  std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("1, 2 or 3 point?", lines[0]);
-  assertEqual("3-pt pH calib...", lines[1]);
-  assertEqual("PHCalibrationPrompt", tc->stateName());
-  tc->loop(false);  // transition to Wait
-  assertEqual("Wait", tc->stateName());
-  delay(2000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationMidThree
-  tc->loop(false);  // updateState to PHCalibrationMidThree
-  assertEqual("PHCalibrationMidThree", tc->stateName());
+  delay(1000);
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationMid
+  tc->loop(false);  // updateState to PHCalibrationMid
+  assertEqual("PHCalibrationMid", tc->stateName());
 }
 
 unittest(badEntry) {
@@ -80,9 +64,9 @@ unittest(badEntry) {
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(3000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to MainMenu
-  tc->loop(false);  // updateState to MainMenu
-  assertEqual("MainMenu", tc->stateName());
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
+  tc->loop(false);  // updateState to SeePHCalibration
+  assertEqual("SeePHCalibration", tc->stateName());
 }
 
 unittest_main()

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -183,10 +183,12 @@ unittest(disableDuringCalibration) {
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
   assertEqual("PHCalibrationMid", tc->stateName());  // test
-  tc->loop(false);
+  tc->loop(false);                                   // without this there is a buffer overflow -- check DataLogger_TC?
+
+  assertEqual("testing", tc->returnState()->stateName());
 
   // device remains off between calibration states
-  test->setValue(7.00);
+  // test->setValue(7.00);
   // tc->loop(false);
   // assertEqual("Wait", tc->stateName());
   // delay(2000);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -171,38 +171,24 @@ unittest(PhEvenWithTarget) {
 unittest(disableDuringCalibration) {
   assertFalse(tc->isInCalibration());
   PHCalibrationMid* test = new PHCalibrationMid(tc, 3);
-  assertEqual(nullptr, tc->returnNextState());
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
-  assertEqual(nullptr, tc->returnNextState());
   // device is initially off and stays off due to calibration
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
-  assertEqual(nullptr, tc->returnNextState());
   assertFalse(controlSolenoid->isOn());
-  assertEqual(nullptr, tc->returnNextState());
   controlSolenoid->setBaseTargetPh(7.50);
   setPhMeasurementTo(8.50);
-  assertEqual(nullptr, tc->returnNextState());
   assertEqual("PHCalibrationMid", tc->stateName());  // test
-  assertEqual(nullptr, tc->returnNextState());
-  tc->loop(false);  // update the controls based on the current readings
-  assertEqual(nullptr, tc->returnNextState());
+  tc->loop(false);                                   // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
-  assertEqual(nullptr, tc->returnNextState());
   assertFalse(controlSolenoid->isOn());
-  assertEqual(nullptr, tc->returnNextState());
+  tc->loop(false);
   assertEqual("PHCalibrationMid", tc->stateName());  // test
-  assertEqual(nullptr, tc->returnNextState());
-  tc->loop(false);  // without this there is a buffer overflow -- check DataLogger_TC?
-
-  assertEqual(nullptr, tc->returnNextState());
+  tc->loop(false);                                   // without this there is a buffer overflow -- check DataLogger_TC?
 
   // device remains off between calibration states
   test->setValue(7.00);
-  // assertEqual("Wait", tc->returnNextState()->name());
   tc->loop(false);
-  // assertEqual(nullptr, tc->returnNextState());
-
   assertEqual("Wait", tc->stateName());
   // delay(2000);
   // tc->loop(false);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -198,7 +198,7 @@ unittest(disableDuringCalibration) {
   assertEqual(nullptr, tc->returnNextState());
 
   // device remains off between calibration states
-  // test->setValue(7.00);
+  test->setValue(7.00);
   // assertEqual("Wait", tc->returnNextState()->name());
   // tc->loop(false);
   // assertEqual(nullptr, tc->returnNextState());

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -170,7 +170,7 @@ unittest(PhEvenWithTarget) {
  */
 unittest(disableDuringCalibration) {
   assertFalse(tc->isInCalibration());
-  PHCalibrationMid* test = new PHCalibrationMid(tc);
+  PHCalibrationMidThree* test = new PHCalibrationMidThree(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // device is initially off and stays off due to calibration

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -178,13 +178,15 @@ unittest(disableDuringCalibration) {
   assertFalse(controlSolenoid->isOn());
   controlSolenoid->setBaseTargetPh(7.50);
   setPhMeasurementTo(8.50);
-  tc->loop(false);  // update the controls based on the current readings
+  assertEqual("PHCalibrationMid", tc->stateName());  // test
+  tc->loop(false);                                   // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
+  assertEqual("PHCalibrationMid", tc->stateName());  // test
 
   // device remains off between calibration states
-  test->setValue(7.00);
-  tc->loop(false);
+  // test->setValue(7.00);
+  // tc->loop(false);
   // assertEqual("Wait", tc->stateName());
   // delay(2000);
   // tc->loop(false);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -185,7 +185,7 @@ unittest(disableDuringCalibration) {
   assertEqual("PHCalibrationMid", tc->stateName());  // test
   tc->loop(false);                                   // without this there is a buffer overflow -- check DataLogger_TC?
 
-  assertEqual("testing", tc->returnState()->stateName());
+  assertEqual("testing", tc->returnState()->name());
 
   // device remains off between calibration states
   // test->setValue(7.00);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -182,14 +182,14 @@ unittest(disableDuringCalibration) {
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
 
-  // devide remains off between calibration states
-  test->setValue(7.00);
-  tc->loop(false);
-  assertEqual("Wait", tc->stateName());
-  delay(2000);
-  tc->loop(false);
-  assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
-  assertFalse(controlSolenoid->isOn());
+  // // device remains off between calibration states
+  // test->setValue(7.00);
+  // tc->loop(false);
+  // assertEqual("Wait", tc->stateName());
+  // delay(2000);
+  // tc->loop(false);
+  // assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
+  // assertFalse(controlSolenoid->isOn());
 }
 
 unittest(RampGreaterThanZero) {

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -178,22 +178,19 @@ unittest(disableDuringCalibration) {
   assertFalse(controlSolenoid->isOn());
   controlSolenoid->setBaseTargetPh(7.50);
   setPhMeasurementTo(8.50);
-  assertEqual("PHCalibrationMid", tc->stateName());  // test
   tc->loop(false);                                   // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
   tc->loop(false);
-  assertEqual("PHCalibrationMid", tc->stateName());  // test
-  tc->loop(false);                                   // without this there is a buffer overflow -- check DataLogger_TC?
 
   // device remains off between calibration states
   test->setValue(7.00);
   tc->loop(false);
   assertEqual("Wait", tc->stateName());
-  // delay(2000);
-  // tc->loop(false);
-  // assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
-  // assertFalse(controlSolenoid->isOn());
+  delay(2000);
+  tc->loop(false);
+  assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
+  assertFalse(controlSolenoid->isOn());
   tc->loop(false);
 }
 

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -184,7 +184,7 @@ unittest(disableDuringCalibration) {
 
   // // device remains off between calibration states
   // test->setValue(7.00);
-  // tc->loop(false);
+  tc->loop(false);
   // assertEqual("Wait", tc->stateName());
   // delay(2000);
   // tc->loop(false);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -16,6 +16,7 @@ const uint16_t PH_CONTROL_PIN = 49;
 GodmodeState* state = GODMODE();
 TankController* tc = TankController::instance();
 PHControl* controlSolenoid = PHControl::instance();
+PHProbe* pPHProbe = PHProbe::instance();
 LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
 DataLogger_TC* dataLog = DataLogger_TC::instance();
 
@@ -28,7 +29,7 @@ void reset() {
   DateTime_TC january(2021, 1, 15, 1, 48, 24);
   january.setAsCurrent();
   controlSolenoid->enablePID(false);
-  PHProbe::instance()->setPh(7.5);
+  pPHProbe->setPh(7.5);
   controlSolenoid->setBaseTargetPh(7.50);
   controlSolenoid->setRampDuration(0);  // No ramp
   state->serialPort[0].dataOut = "";    // the history of data written
@@ -48,7 +49,7 @@ unittest(bubblerTurnsOnAndOff) {
   assertEqual(10, millis());
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
-  PHProbe::instance()->setPh(8.0);
+  pPHProbe->setPh(8.0);
   tc->loop(false);  // update the controls based on the current readings
   assertEqual(13, millis());
   assertEqual(TURN_SOLENOID_ON, state->digitalPin[PH_CONTROL_PIN]);
@@ -79,17 +80,17 @@ unittest(afterTenSecondsButPhStillHigher) {
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
   controlSolenoid->setBaseTargetPh(7.50);
-  PHProbe::instance()->setPh(8.5);
+  pPHProbe->setPh(8.5);
   tc->loop(false);  // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_ON, state->digitalPin[PH_CONTROL_PIN]);
   assertTrue(controlSolenoid->isOn());
   delay(8000);
-  PHProbe::instance()->setPh(8.5);
+  pPHProbe->setPh(8.5);
   tc->loop(false);  // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_ON, state->digitalPin[PH_CONTROL_PIN]);
   assertTrue(controlSolenoid->isOn());
   delay(2000);
-  PHProbe::instance()->setPh(7.75);
+  pPHProbe->setPh(7.75);
   tc->loop(false);  // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_ON, state->digitalPin[PH_CONTROL_PIN]);
   assertTrue(controlSolenoid->isOn());
@@ -100,7 +101,7 @@ unittest(afterTenSecondsAndPhIsLower) {
   assertFalse(controlSolenoid->isOn());
   assertEqual("pH 7.500   7.500", lc->getLines().at(0));
   controlSolenoid->setBaseTargetPh(7.50);
-  PHProbe::instance()->setPh(8.5);
+  pPHProbe->setPh(8.5);
   tc->loop(false);  // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_ON, state->digitalPin[PH_CONTROL_PIN]);
   assertTrue(controlSolenoid->isOn());
@@ -118,7 +119,7 @@ unittest(afterTenSecondsAndPhIsLower) {
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
   delay(1000);
-  PHProbe::instance()->setPh(7.25);
+  pPHProbe->setPh(7.25);
   tc->loop(false);  // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
@@ -134,12 +135,12 @@ unittest(beforeTenSecondsButPhIsLower) {
   assertFalse(controlSolenoid->isOn());
   delay(1000);
   controlSolenoid->setBaseTargetPh(7.50);
-  PHProbe::instance()->setPh(8.5);
+  pPHProbe->setPh(8.5);
   tc->loop(false);  // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_ON, state->digitalPin[PH_CONTROL_PIN]);
   assertTrue(controlSolenoid->isOn());
   delay(7500);
-  PHProbe::instance()->setPh(7.25);
+  pPHProbe->setPh(7.25);
   tc->loop(false);  // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
@@ -149,7 +150,7 @@ unittest(PhEvenWithTarget) {
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
   controlSolenoid->setBaseTargetPh(7.50);
-  PHProbe::instance()->setPh(7.5);
+  pPHProbe->setPh(7.5);
   tc->loop(false);  // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
@@ -168,7 +169,7 @@ unittest(disableDuringCalibration) {
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
   controlSolenoid->setBaseTargetPh(7.50);
-  PHProbe::instance()->setPh(8.5);
+  pPHProbe->setPh(8.5);
   tc->loop(false);  // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
@@ -189,7 +190,7 @@ unittest(RampGreaterThanZero) {
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
   delay(11000);
-  PHProbe::instance()->setPh(8.5);
+  pPHProbe->setPh(8.5);
   controlSolenoid->setBaseTargetPh(7.00);
   controlSolenoid->setRampDuration(1.5);  // 90 minutes
   assertEqual(PHControl::RAMP_TYPE, controlSolenoid->getPhSetType());
@@ -233,7 +234,7 @@ unittest(RampGreaterThanZero) {
 unittest(ChangeRampToZero) {
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
-  PHProbe::instance()->setPh(8.5);
+  pPHProbe->setPh(8.5);
   tc->loop(false);  // update the controls based on the current readings
   controlSolenoid->setBaseTargetPh(7.00);
   controlSolenoid->setRampDuration(1.5);
@@ -249,7 +250,7 @@ unittest(ChangeRampToZero) {
 unittest(sineTest) {
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
-  PHProbe::instance()->setPh(7.0);
+  pPHProbe->setPh(7.0);
   tc->loop(false);  // update the controls based on the current readings
   controlSolenoid->setBaseTargetPh(7.00);
   controlSolenoid->setSine(1.5, 2);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -198,7 +198,8 @@ unittest(disableDuringCalibration) {
   assertEqual(nullptr, tc->returnNextState());
 
   // device remains off between calibration states
-  // test->setValue(7.00);
+  test->setValue(7.00);
+  assertEqual("Wait", tc->returnNextState()->name());
   // tc->loop(false);
   // assertEqual("Wait", tc->stateName());
   // delay(2000);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -170,7 +170,7 @@ unittest(PhEvenWithTarget) {
  */
 unittest(disableDuringCalibration) {
   assertFalse(tc->isInCalibration());
-  PHCalibrationMidThree* test = new PHCalibrationMidThree(tc);
+  PHCalibrationMid* test = new PHCalibrationMid(tc, 3);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // device is initially off and stays off due to calibration

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -200,7 +200,8 @@ unittest(disableDuringCalibration) {
   // device remains off between calibration states
   test->setValue(7.00);
   assertEqual("Wait", tc->returnNextState()->name());
-  // tc->loop(false);
+  tc->loop(false);
+  assertEqual(nullptr, tc->returnNextState());
   // assertEqual("Wait", tc->stateName());
   // delay(2000);
   // tc->loop(false);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -198,10 +198,11 @@ unittest(disableDuringCalibration) {
   assertEqual(nullptr, tc->returnNextState());
 
   // device remains off between calibration states
-  test->setValue(7.00);
-  assertEqual("Wait", tc->returnNextState()->name());
-  tc->loop(false);
-  assertEqual(nullptr, tc->returnNextState());
+  // test->setValue(7.00);
+  // assertEqual("Wait", tc->returnNextState()->name());
+  // tc->loop(false);
+  // assertEqual(nullptr, tc->returnNextState());
+
   // assertEqual("Wait", tc->stateName());
   // delay(2000);
   // tc->loop(false);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -178,7 +178,7 @@ unittest(disableDuringCalibration) {
   assertFalse(controlSolenoid->isOn());
   controlSolenoid->setBaseTargetPh(7.50);
   setPhMeasurementTo(8.50);
-  tc->loop(false);                                   // update the controls based on the current readings
+  tc->loop(false);  // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
   tc->loop(false);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -171,21 +171,31 @@ unittest(PhEvenWithTarget) {
 unittest(disableDuringCalibration) {
   assertFalse(tc->isInCalibration());
   PHCalibrationMid* test = new PHCalibrationMid(tc, 3);
+  assertEqual(nullptr, tc->returnNextState());
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
+  assertEqual(nullptr, tc->returnNextState());
   // device is initially off and stays off due to calibration
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
+  assertEqual(nullptr, tc->returnNextState());
   assertFalse(controlSolenoid->isOn());
+  assertEqual(nullptr, tc->returnNextState());
   controlSolenoid->setBaseTargetPh(7.50);
   setPhMeasurementTo(8.50);
+  assertEqual(nullptr, tc->returnNextState());
   assertEqual("PHCalibrationMid", tc->stateName());  // test
-  tc->loop(false);                                   // update the controls based on the current readings
+  assertEqual(nullptr, tc->returnNextState());
+  tc->loop(false);  // update the controls based on the current readings
+  assertEqual(nullptr, tc->returnNextState());
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
+  assertEqual(nullptr, tc->returnNextState());
   assertFalse(controlSolenoid->isOn());
+  assertEqual(nullptr, tc->returnNextState());
   assertEqual("PHCalibrationMid", tc->stateName());  // test
-  tc->loop(false);                                   // without this there is a buffer overflow -- check DataLogger_TC?
+  assertEqual(nullptr, tc->returnNextState());
+  tc->loop(false);  // without this there is a buffer overflow -- check DataLogger_TC?
 
-  assertEqual("testing", tc->returnState()->name());
+  assertEqual(nullptr, tc->returnNextState());
 
   // device remains off between calibration states
   // test->setValue(7.00);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -200,14 +200,15 @@ unittest(disableDuringCalibration) {
   // device remains off between calibration states
   test->setValue(7.00);
   // assertEqual("Wait", tc->returnNextState()->name());
-  // tc->loop(false);
+  tc->loop(false);
   // assertEqual(nullptr, tc->returnNextState());
 
-  // assertEqual("Wait", tc->stateName());
+  assertEqual("Wait", tc->stateName());
   // delay(2000);
   // tc->loop(false);
   // assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   // assertFalse(controlSolenoid->isOn());
+  tc->loop(false);
 }
 
 unittest(RampGreaterThanZero) {

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -183,9 +183,10 @@ unittest(disableDuringCalibration) {
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
   assertEqual("PHCalibrationMid", tc->stateName());  // test
+  tc->loop(false);
 
   // device remains off between calibration states
-  // test->setValue(7.00);
+  test->setValue(7.00);
   // tc->loop(false);
   // assertEqual("Wait", tc->stateName());
   // delay(2000);

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -181,6 +181,15 @@ unittest(disableDuringCalibration) {
   tc->loop(false);  // update the controls based on the current readings
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
+
+  // devide remains off between calibration states
+  test->setValue(7.00);
+  tc->loop(false);
+  assertEqual("Wait", tc->stateName());
+  delay(2000);
+  tc->loop(false);
+  assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
+  assertFalse(controlSolenoid->isOn());
 }
 
 unittest(RampGreaterThanZero) {

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -182,8 +182,8 @@ unittest(disableDuringCalibration) {
   assertEqual(TURN_SOLENOID_OFF, state->digitalPin[PH_CONTROL_PIN]);
   assertFalse(controlSolenoid->isOn());
 
-  // // device remains off between calibration states
-  // test->setValue(7.00);
+  // device remains off between calibration states
+  test->setValue(7.00);
   tc->loop(false);
   // assertEqual("Wait", tc->stateName());
   // delay(2000);

--- a/test/PHProbeTest.cpp
+++ b/test/PHProbeTest.cpp
@@ -25,9 +25,9 @@ unittest(serialEvent1) {
   tc->serialEvent1();                       // fake interrupt
   assertEqual(0, pPHProbe->getPh());
   assertEqual("", pPHProbe->getSlopeResponse());
-  PHProbe::instance()->setPh(7.125);
-  PHProbe::instance()->setPhSlope();
-  assertEqual("?SLOPE,99.7,100.3,-0.89", pPHProbe->getSlopeResponse());
+  pPHProbe->setPh(7.125);
+  pPHProbe->setPhSlope();
+  assertEqual("99.7,100.3,-0.89", pPHProbe->getSlopeResponse());
   assertEqual(7.125, pPHProbe->getPh());
 }
 
@@ -84,7 +84,7 @@ unittest(sendSlopeRequest) {
   state->reset();
   state->serialPort[0].dataOut = "";
   PHProbe::instance()->sendSlopeRequest();
-  assertEqual("SLOPE,?\r", GODMODE()->serialPort[1].dataOut);
+  assertEqual("SLOPE,?\r", state->serialPort[1].dataOut);
 }
 
 // this test assumes that earlier tests have run and that there is a slope available
@@ -108,7 +108,6 @@ unittest(getSlope) {
 
 unittest(getPh) {
   GodmodeState *state = GODMODE();
-  TankController *tc = TankController::instance();
   state->serialPort[0].dataOut = "";
   state->reset();
   PHProbe::instance()->setPh(7.25);
@@ -121,7 +120,7 @@ unittest(clearCalibration) {
   GodmodeState *state = GODMODE();
   state->reset();
   PHProbe::instance()->clearCalibration();
-  assertEqual("Cal,clear\r", GODMODE()->serialPort[1].dataOut);
+  assertEqual("Cal,clear\r", state->serialPort[1].dataOut);
 }
 
 unittest_main()

--- a/test/PHProbeTest.cpp
+++ b/test/PHProbeTest.cpp
@@ -15,6 +15,26 @@ unittest(constructor) {
   assertEqual("*OK,0\rC,1\r", GODMODE()->serialPort[1].dataOut);
 }
 
+// tests getPh() and getSlopeResponse as well
+unittest(serialEvent1) {
+  GodmodeState *state = GODMODE();
+  state->reset();
+  TankController *tc = TankController::instance();
+  assertEqual("", state->serialPort[0].dataOut);
+  assertEqual("", state->serialPort[1].dataOut);
+  PHProbe *pPHProbe = PHProbe::instance();  // the constructor writes data to the serial port
+  tc->serialEvent1();                       // fake interrupt
+  assertEqual("", pPHProbe->getCalibrationResponse());
+  assertEqual(0, pPHProbe->getPh());
+  assertEqual("", pPHProbe->getSlopeResponse());
+  pPHProbe->setCalibration(2);
+  pPHProbe->setPh(7.125);
+  pPHProbe->setPhSlope();
+  assertEqual("2 point", pPHProbe->getCalibrationResponse());
+  assertEqual(7.125, pPHProbe->getPh());
+  assertEqual("99.7,100.3,-0.89", pPHProbe->getSlopeResponse());
+}
+
 unittest(clearCalibration) {
   GodmodeState *state = GODMODE();
   state->reset();
@@ -29,7 +49,7 @@ unittest(sendCalibrationRequest) {
   assertEqual("", state->serialPort[1].dataOut);
   PHProbe::instance()->sendCalibrationRequest();
   assertEqual("CAL,?\r", state->serialPort[1].dataOut);
-  char buffer[10];
+  char buffer[20];
   PHProbe::instance()->getCalibration(buffer, sizeof(buffer));
   assertEqual("Requesting...", buffer);
 }
@@ -47,25 +67,6 @@ unittest(getCalibration) {
   pPHProbe->setCalibration(3);
   pPHProbe->getCalibration(buffer, sizeof(buffer));
   assertEqual("3 point", buffer);
-}
-
-// tests getPh() and getSlopeResponse as well
-unittest(serialEvent1) {
-  GodmodeState *state = GODMODE();
-  state->reset();
-  TankController *tc = TankController::instance();
-  assertEqual("", state->serialPort[0].dataOut);
-  PHProbe *pPHProbe = PHProbe::instance();  // the constructor writes data to the serial port
-  tc->serialEvent1();                       // fake interrupt
-  assertEqual("", pPHProbe->getCalibrationResponse());
-  assertEqual(0, pPHProbe->getPh());
-  assertEqual("", pPHProbe->getSlopeResponse());
-  pPHProbe->setCalibration(2);
-  pPHProbe->setPh(7.125);
-  pPHProbe->setPhSlope();
-  assertEqual("2 point", pPHProbe->getCalibrationResponse());
-  assertEqual(7.125, pPHProbe->getPh());
-  assertEqual("99.7,100.3,-0.89", pPHProbe->getSlopeResponse());
 }
 
 unittest(setTemperatureCompensation) {

--- a/test/PHProbeTest.cpp
+++ b/test/PHProbeTest.cpp
@@ -20,7 +20,7 @@ unittest(serialEvent1) {
   GodmodeState *state = GODMODE();
   state->reset();
   TankController *tc = TankController::instance();
-  assertEqual("", state->serialPort[0].dataOut);
+  state->serialPort[0].dataOut = "";
   assertEqual("", state->serialPort[1].dataOut);
   PHProbe *pPHProbe = PHProbe::instance();  // the constructor writes data to the serial port
   tc->serialEvent1();                       // fake interrupt

--- a/test/PHProbeTest.cpp
+++ b/test/PHProbeTest.cpp
@@ -27,7 +27,7 @@ unittest(serialEvent1) {
   assertEqual("", pPHProbe->getSlopeResponse());
   GODMODE()->serialPort[1].dataIn = "7.125\r?SLOPE,99.7,100.3,-0.89\r";  // the queue of data waiting to be read
   tc->serialEvent1();                                                    // fake interrupt
-  assertEqual("?SLOPE,99.7,100.3,-0.89", pPHProbe->getSlopeResponse());
+  assertEqual("99.7,100.3,-0.89", pPHProbe->getSlopeResponse());
   assertEqual(7.125, pPHProbe->getPh());
 }
 

--- a/test/PushingBoxTest.cpp
+++ b/test/PushingBoxTest.cpp
@@ -111,7 +111,7 @@ unittest(SendData) {
 unittest(inCalibration) {
   // set tank id
   EEPROM_TC::instance()->setTankID(99);
-  PHCalibrationMidThree *test = new PHCalibrationMidThree(tc);
+  PHCalibrationMid *test = new PHCalibrationMid(tc, 3);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   EthernetClient::startMockServer(pPushingBox->getServer(), (uint32_t)0, 80);

--- a/test/PushingBoxTest.cpp
+++ b/test/PushingBoxTest.cpp
@@ -111,7 +111,7 @@ unittest(SendData) {
 unittest(inCalibration) {
   // set tank id
   EEPROM_TC::instance()->setTankID(99);
-  PHCalibrationMid *test = new PHCalibrationMid(tc);
+  PHCalibrationMidThree *test = new PHCalibrationMidThree(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   EthernetClient::startMockServer(pPushingBox->getServer(), (uint32_t)0, 80);

--- a/test/SDTest.cpp
+++ b/test/SDTest.cpp
@@ -48,7 +48,7 @@ unittest(tankControllerLoop) {
 
 unittest(loopInCalibration) {
   TankController* tc = TankController::instance();
-  PHCalibrationMid* test = new PHCalibrationMid(tc);
+  PHCalibrationMidThree* test = new PHCalibrationMidThree(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   char data[250];

--- a/test/SDTest.cpp
+++ b/test/SDTest.cpp
@@ -48,7 +48,7 @@ unittest(tankControllerLoop) {
 
 unittest(loopInCalibration) {
   TankController* tc = TankController::instance();
-  PHCalibrationMidThree* test = new PHCalibrationMidThree(tc);
+  PHCalibrationMid* test = new PHCalibrationMid(tc, 3);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   char data[250];

--- a/test/SeePHCalibrationTest.cpp
+++ b/test/SeePHCalibrationTest.cpp
@@ -16,7 +16,7 @@ unittest(testOutput) {
   pPHProbe->setCalibrationPoints(3);
 
   assertEqual("MainMenu", tc->stateName());
-  SeePHSlope* test = new SeePHCalibration(tc);
+  SeePHCalibration* test = new SeePHCalibration(tc);
   tc->setNextState(test, true);
   assertEqual("SeePHCalibration", tc->stateName());
 

--- a/test/SeePHCalibrationTest.cpp
+++ b/test/SeePHCalibrationTest.cpp
@@ -12,7 +12,6 @@ unittest(testOutput) {
   TankController* tc = TankController::instance();
   LiquidCrystal_TC* display = LiquidCrystal_TC::instance();
   PHProbe* pPHProbe = PHProbe::instance();
-  char buffer[20];
   pPHProbe->setCalibrationPoints(3);
 
   assertEqual("MainMenu", tc->stateName());
@@ -22,10 +21,10 @@ unittest(testOutput) {
 
   // Test the output
   assertEqual("PH Calibration: ", display->getLines().at(0));
-  assertEqual("requesting calib", display->getLines().at(1));
+  // assertEqual("requesting calib", display->getLines().at(1));
   tc->loop(false);
   assertEqual("Requesting...   ", display->getLines().at(1));
-  pPHProbe->setCalibrationPoints(3);
+  // pPHProbe->setCalibrationPoints(3);
   tc->loop(false);
   assertEqual("3 point         ", display->getLines().at(1));
   // Return to mainMenu

--- a/test/SeePHCalibrationTest.cpp
+++ b/test/SeePHCalibrationTest.cpp
@@ -22,9 +22,10 @@ unittest(testOutput) {
 
   // Test the output
   assertEqual("PH Calibration: ", display->getLines().at(0));
-  assertEqual("requesting slope", display->getLines().at(1));
+  assertEqual("requesting calib", display->getLines().at(1));
   tc->loop(false);
   assertEqual("Requesting...   ", display->getLines().at(1));
+  pPHProbe->setCalibrationPoints(3);
   tc->loop(false);
   assertEqual("3 point         ", display->getLines().at(1));
   // Return to mainMenu

--- a/test/SeePHCalibrationTest.cpp
+++ b/test/SeePHCalibrationTest.cpp
@@ -21,10 +21,8 @@ unittest(testOutput) {
 
   // Test the output
   assertEqual("PH Calibration: ", display->getLines().at(0));
-  // assertEqual("requesting calib", display->getLines().at(1));
   tc->loop(false);
   assertEqual("Requesting...   ", display->getLines().at(1));
-  // pPHProbe->setCalibrationPoints(3);
   tc->loop(false);
   assertEqual("3 point         ", display->getLines().at(1));
   // Return to mainMenu

--- a/test/SeePHCalibrationTest.cpp
+++ b/test/SeePHCalibrationTest.cpp
@@ -1,0 +1,35 @@
+#include <Arduino.h>
+#include <ArduinoUnitTests.h>
+
+#include "Keypad_TC.h"
+#include "LiquidCrystal_TC.h"
+#include "SeePHCalibration.h"
+#include "TankController.h"
+
+unittest(testOutput) {
+  // Set up
+  TankController* tc = TankController::instance();
+  LiquidCrystal_TC* display = LiquidCrystal_TC::instance();
+  PHProbe* pPHProbe = PHProbe::instance();
+  char buffer[20];
+  pPHProbe->setCalibrationPoints(3);
+
+  assertEqual("MainMenu", tc->stateName());
+  SeePHSlope* test = new SeePHSlope(tc);
+  tc->setNextState(test, true);
+  assertEqual("SeePHSlope", tc->stateName());
+
+  // Test the output
+  assertEqual("PH Slope:       ", display->getLines().at(0));
+  assertEqual("requesting slope", display->getLines().at(1));
+  tc->loop(false);
+  assertEqual("Requesting...   ", display->getLines().at(1));
+  tc->loop(false);
+  assertEqual("3 point         ", display->getLines().at(1));
+  // Return to mainMenu
+  Keypad_TC::instance()->_getPuppet()->push_back('D');
+  tc->loop(false);
+  assertEqual("MainMenu", tc->stateName());
+}
+
+unittest_main()

--- a/test/SeePHCalibrationTest.cpp
+++ b/test/SeePHCalibrationTest.cpp
@@ -12,7 +12,6 @@ unittest(testOutput) {
   TankController* tc = TankController::instance();
   LiquidCrystal_TC* display = LiquidCrystal_TC::instance();
   PHProbe* pPHProbe = PHProbe::instance();
-  pPHProbe->setCalibration(2);
 
   assertEqual("MainMenu", tc->stateName());
   SeePHCalibration* test = new SeePHCalibration(tc);
@@ -23,8 +22,7 @@ unittest(testOutput) {
   assertEqual("PH Calibration: ", display->getLines().at(0));
   tc->loop(false);
   assertEqual("Requesting...   ", display->getLines().at(1));
-  tc->serialEvent1();  // fake interrupt
-  tc->loop(false);
+  pPHProbe->setCalibration(2);
   assertEqual("2 point         ", display->getLines().at(1));
   // Return to mainMenu
   Keypad_TC::instance()->_getPuppet()->push_back('D');

--- a/test/SeePHCalibrationTest.cpp
+++ b/test/SeePHCalibrationTest.cpp
@@ -12,7 +12,7 @@ unittest(testOutput) {
   TankController* tc = TankController::instance();
   LiquidCrystal_TC* display = LiquidCrystal_TC::instance();
   PHProbe* pPHProbe = PHProbe::instance();
-  pPHProbe->setCalibrationPoints(3);
+  pPHProbe->setCalibration(2);
 
   assertEqual("MainMenu", tc->stateName());
   SeePHCalibration* test = new SeePHCalibration(tc);
@@ -23,8 +23,9 @@ unittest(testOutput) {
   assertEqual("PH Calibration: ", display->getLines().at(0));
   tc->loop(false);
   assertEqual("Requesting...   ", display->getLines().at(1));
+  tc->serialEvent1();  // fake interrupt
   tc->loop(false);
-  assertEqual("3 point         ", display->getLines().at(1));
+  assertEqual("2 point         ", display->getLines().at(1));
   // Return to mainMenu
   Keypad_TC::instance()->_getPuppet()->push_back('D');
   tc->loop(false);

--- a/test/SeePHCalibrationTest.cpp
+++ b/test/SeePHCalibrationTest.cpp
@@ -3,6 +3,7 @@
 
 #include "Keypad_TC.h"
 #include "LiquidCrystal_TC.h"
+#include "PHProbe.h"
 #include "SeePHCalibration.h"
 #include "TankController.h"
 
@@ -15,12 +16,12 @@ unittest(testOutput) {
   pPHProbe->setCalibrationPoints(3);
 
   assertEqual("MainMenu", tc->stateName());
-  SeePHSlope* test = new SeePHSlope(tc);
+  SeePHSlope* test = new SeePHCalibration(tc);
   tc->setNextState(test, true);
-  assertEqual("SeePHSlope", tc->stateName());
+  assertEqual("SeePHCalibration", tc->stateName());
 
   // Test the output
-  assertEqual("PH Slope:       ", display->getLines().at(0));
+  assertEqual("PH Calibration: ", display->getLines().at(0));
   assertEqual("requesting slope", display->getLines().at(1));
   tc->loop(false);
   assertEqual("Requesting...   ", display->getLines().at(1));

--- a/test/SeePHSlopeTest.cpp
+++ b/test/SeePHSlopeTest.cpp
@@ -3,6 +3,7 @@
 
 #include "Keypad_TC.h"
 #include "LiquidCrystal_TC.h"
+#include "PHProbe.h"
 #include "SeePHSlope.h"
 #include "TankController.h"
 
@@ -10,8 +11,7 @@ unittest(testOutput) {
   // Set up
   TankController* tc = TankController::instance();
   LiquidCrystal_TC* display = LiquidCrystal_TC::instance();
-  GODMODE()->serialPort[1].dataIn = "?SLOPE,99.7,100.3,-0.89\r";  // the queue of data waiting to be read
-  tc->serialEvent1();                                             // fake interrupt
+  PHProbe* pPHProbe = PHProbe::instance();
 
   assertEqual("MainMenu", tc->stateName());
   SeePHSlope* test = new SeePHSlope(tc);
@@ -20,11 +20,8 @@ unittest(testOutput) {
 
   // Test the output
   assertEqual("PH Slope:       ", display->getLines().at(0));
-  assertEqual("requesting slope", display->getLines().at(1));
   tc->loop(false);
   assertEqual("Requesting...   ", display->getLines().at(1));
-  GODMODE()->serialPort[1].dataIn = "?SLOPE,99.7,100.3,-0.89\r";  // the queue of data waiting to be read
-  tc->serialEvent1();                                             // fake interrupt
   tc->loop(false);
   assertEqual("99.7,100.3,-0.89", display->getLines().at(1));
   // Return to mainMenu

--- a/test/SeePHSlopeTest.cpp
+++ b/test/SeePHSlopeTest.cpp
@@ -22,6 +22,7 @@ unittest(testOutput) {
   assertEqual("PH Slope:       ", display->getLines().at(0));
   tc->loop(false);
   assertEqual("Requesting...   ", display->getLines().at(1));
+  tc->serialEvent1();  // fake interrupt
   tc->loop(false);
   assertEqual("99.7,100.3,-0.89", display->getLines().at(1));
   // Return to mainMenu

--- a/test/SeePHSlopeTest.cpp
+++ b/test/SeePHSlopeTest.cpp
@@ -4,7 +4,6 @@
 #include "Devices/PHProbe.h"
 #include "Keypad_TC.h"
 #include "LiquidCrystal_TC.h"
-#include "PHProbe.h"
 #include "SeePHSlope.h"
 #include "TankController.h"
 

--- a/test/SeePHSlopeTest.cpp
+++ b/test/SeePHSlopeTest.cpp
@@ -22,7 +22,7 @@ unittest(testOutput) {
   assertEqual("PH Slope:       ", display->getLines().at(0));
   assertEqual("requesting slope", display->getLines().at(1));
   tc->loop(false);
-  assertEqual("Requesting...", display->getLines().at(1));
+  assertEqual("Requesting...   ", display->getLines().at(1));
   GODMODE()->serialPort[1].dataIn = "?SLOPE,99.7,100.3,-0.89\r";  // the queue of data waiting to be read
   tc->serialEvent1();                                             // fake interrupt
   tc->loop(false);

--- a/test/SeePHSlopeTest.cpp
+++ b/test/SeePHSlopeTest.cpp
@@ -22,8 +22,7 @@ unittest(testOutput) {
   assertEqual("PH Slope:       ", display->getLines().at(0));
   tc->loop(false);
   assertEqual("Requesting...   ", display->getLines().at(1));
-  tc->serialEvent1();  // fake interrupt
-  tc->loop(false);
+  pPHProbe->setPhSlope();
   assertEqual("99.7,100.3,-0.89", display->getLines().at(1));
   // Return to mainMenu
   Keypad_TC::instance()->_getPuppet()->push_back('D');

--- a/test/SeePHSlopeTest.cpp
+++ b/test/SeePHSlopeTest.cpp
@@ -22,7 +22,7 @@ unittest(testOutput) {
   assertEqual("PH Slope:       ", display->getLines().at(0));
   assertEqual("requesting slope", display->getLines().at(1));
   tc->loop(false);
-  assertEqual("Slope requested!", display->getLines().at(1));
+  assertEqual("Requesting...", display->getLines().at(1));
   GODMODE()->serialPort[1].dataIn = "?SLOPE,99.7,100.3,-0.89\r";  // the queue of data waiting to be read
   tc->serialEvent1();                                             // fake interrupt
   tc->loop(false);

--- a/test/SeePhTest.cpp
+++ b/test/SeePhTest.cpp
@@ -14,6 +14,7 @@
 GodmodeState *state = GODMODE();
 TankController *tc = TankController::instance();
 PHControl *controlSolenoid = PHControl::instance();
+PHProbe *pPHProbe = PHProbe::instance();
 LiquidCrystal_TC *lc = LiquidCrystal_TC::instance();
 
 unittest_setup() {
@@ -21,16 +22,8 @@ unittest_setup() {
   january.setAsCurrent();
 }
 
-// void setPhMeasurementTo(float value) {
-//   char buffer[10];
-//   snprintf_P(buffer, sizeof(buffer), (PGM_P)F("%i.%03i\r"), (int)value, (int)(value * 1000 + 0.5) % 1000);
-//   state->serialPort[1].dataIn = buffer;  // the queue of data waiting to be read
-//   tc->serialEvent1();                    // fake interrupt to update the current pH reading
-//   tc->loop(false);                       // update the controls based on the current readings
-// }
-
 unittest(TestVerticalScrollWithFlatSet) {
-  PHProbe::instance()->setPh(7.062);
+  pPHProbe->setPh(7.062);
   controlSolenoid->setBaseTargetPh(7.062);
   SeePh *test = new SeePh(tc);
 
@@ -41,30 +34,25 @@ unittest(TestVerticalScrollWithFlatSet) {
   assertEqual("SeePh", tc->stateName());
 
   // Set up
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
 
   // during the delay we cycle through displays
   assertEqual("Now  Next  Goal ", lc->getLines().at(0));
   assertEqual("7.06 7.062 7.062", lc->getLines().at(1));
   delay(1000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("Now  Next  Goal ", lc->getLines().at(0));
   assertEqual("7.06 7.062 7.062", lc->getLines().at(1));
   delay(2000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("type: flat      ", lc->getLines().at(0));
   assertEqual("7.06 7.062 7.062", lc->getLines().at(1));
   delay(3000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("Now  Next  Goal ", lc->getLines().at(0));
   assertEqual("7.06 7.062 7.062", lc->getLines().at(1));
   delay(3000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("type: flat      ", lc->getLines().at(0));
   assertEqual("7.06 7.062 7.062", lc->getLines().at(1));
 
@@ -74,8 +62,7 @@ unittest(TestVerticalScrollWithFlatSet) {
 }
 
 unittest(TestVerticalScrollWithRampSet) {
-  PHProbe::instance()->setPh(8.50);
-  // setPhMeasurementTo(8.50);
+  pPHProbe->setPh(8.50);
   controlSolenoid->setBaseTargetPh(7.00);
   controlSolenoid->setRampDuration(0.005);  // 18 seconds
   SeePh *test = new SeePh(tc);
@@ -87,40 +74,33 @@ unittest(TestVerticalScrollWithRampSet) {
   assertEqual("SeePh", tc->stateName());
 
   // Set up
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
 
   // during the delay we cycle through displays
   assertEqual("Now  Next  Goal ", lc->getLines().at(0));
   assertEqual("8.50 8.500 7.000", lc->getLines().at(1));
   delay(1000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("Now  Next  Goal ", lc->getLines().at(0));
   assertEqual("8.50 8.417 7.000", lc->getLines().at(1));
   delay(2000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("type: ramp      ", lc->getLines().at(0));
   assertEqual("left: 0:0:15    ", lc->getLines().at(1));
   delay(3000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("Now  Next  Goal ", lc->getLines().at(0));
   assertEqual("8.25 8.000 7.000", lc->getLines().at(1));
   delay(3000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("type: ramp      ", lc->getLines().at(0));
   assertEqual("left: 0:0:9     ", lc->getLines().at(1));
   delay(1000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("type: ramp      ", lc->getLines().at(0));
   assertEqual("left: 0:0:8     ", lc->getLines().at(1));
   delay(8000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("Now  Next  Goal ", lc->getLines().at(0));
   assertEqual("7.67 7.000 7.000", lc->getLines().at(1));
   delay(3000);
@@ -128,8 +108,7 @@ unittest(TestVerticalScrollWithRampSet) {
   assertEqual("type: ramp      ", lc->getLines().at(0));
   assertEqual("left: 0:0:0     ", lc->getLines().at(1));
   delay(3000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("Now  Next  Goal ", lc->getLines().at(0));
   assertEqual("7.00 7.000 7.000", lc->getLines().at(1));
 
@@ -139,8 +118,7 @@ unittest(TestVerticalScrollWithRampSet) {
 }
 
 unittest(TestVerticalScrollWithSineSet) {
-  PHProbe::instance()->setPh(8.50);
-  // setPhMeasurementTo(8.50);
+  pPHProbe->setPh(8.50);
   controlSolenoid->setBaseTargetPh(7.00);
   controlSolenoid->setSine(1.5, 0.125);
   SeePh *test = new SeePh(tc);
@@ -152,30 +130,25 @@ unittest(TestVerticalScrollWithSineSet) {
   assertEqual("SeePh", tc->stateName());
 
   // Set up
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
 
   // during the delay we cycle through displays
   assertEqual("Now  Next  Goal ", lc->getLines().at(0));
   assertEqual("7.00 7.000 7.000", lc->getLines().at(1));
   delay(1000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("Now  Next  Goal ", lc->getLines().at(0));
   assertEqual("7.00 7.021 7.000", lc->getLines().at(1));
   delay(2000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("type: sine      ", lc->getLines().at(0));
   assertEqual("p=0.125 a=1.500 ", lc->getLines().at(1));
   delay(3000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("Now  Next  Goal ", lc->getLines().at(0));
   assertEqual("7.06 7.126 7.000", lc->getLines().at(1));
   delay(3000);
-  PHProbe::instance()->setPh(controlSolenoid->getCurrentTargetPh());
-  // setPhMeasurementTo(controlSolenoid->getCurrentTargetPh());
+  pPHProbe->setPh(controlSolenoid->getCurrentTargetPh());
   assertEqual("type: sine      ", lc->getLines().at(0));
   assertEqual("p=0.125 a=1.500 ", lc->getLines().at(1));
 

--- a/test/SetPHCalibClearTest.cpp
+++ b/test/SetPHCalibClearTest.cpp
@@ -24,6 +24,7 @@ unittest(test) {
   enterKey('A');
   tc->loop();
   assertEqual("SeePHCalibration", tc->stateName());
+  assertFalse(tc->isInCalibration());
 }
 
 unittest_main()

--- a/test/TCLibTest.cpp
+++ b/test/TCLibTest.cpp
@@ -45,10 +45,6 @@ unittest_setup() {
   // set Kp, Ki, and Kd
   PID_TC::instance()->setTunings(123456.7, 12345.6, 1234.5);
 
-  // EEPROM_TC::instance()->setKP(123456.7);
-  // EEPROM_TC::instance()->setKI(12345.6);
-  // EEPROM_TC::instance()->setKD(1234.5);
-
   // clear SD card
   sd->format();
 }

--- a/test/TemperatureControlTest.cpp
+++ b/test/TemperatureControlTest.cpp
@@ -114,7 +114,7 @@ unittest(disableChillerDuringCalibration) {
   control->setTargetTemperature(20);
   control->updateControl(20);
   assertFalse(tc->isInCalibration());
-  PHCalibrationMidThree* test = new PHCalibrationMidThree(tc);
+  PHCalibrationMid* test = new PHCalibrationMid(tc, 3);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // chiller is initially off and stays off during calibration
@@ -171,7 +171,7 @@ unittest(disableHeaterDuringCalibration) {
   TemperatureControl::enableHeater(true);
   control = TemperatureControl::instance();
   assertFalse(tc->isInCalibration());
-  PHCalibrationMidThree* test = new PHCalibrationMidThree(tc);
+  PHCalibrationMid* test = new PHCalibrationMid(tc, 3);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // heater is initially off, and stays off due to calibration

--- a/test/TemperatureControlTest.cpp
+++ b/test/TemperatureControlTest.cpp
@@ -114,7 +114,7 @@ unittest(disableChillerDuringCalibration) {
   control->setTargetTemperature(20);
   control->updateControl(20);
   assertFalse(tc->isInCalibration());
-  PHCalibrationMid* test = new PHCalibrationMid(tc);
+  PHCalibrationMidThree* test = new PHCalibrationMidThree(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // chiller is initially off and stays off during calibration
@@ -171,7 +171,7 @@ unittest(disableHeaterDuringCalibration) {
   TemperatureControl::enableHeater(true);
   control = TemperatureControl::instance();
   assertFalse(tc->isInCalibration());
-  PHCalibrationMid* test = new PHCalibrationMid(tc);
+  PHCalibrationMidThree* test = new PHCalibrationMidThree(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // heater is initially off, and stays off due to calibration


### PR DESCRIPTION
Addresses #325. When the user is calibrating the pH probe:

- First the user is asked whether there will be 1, 2, or 3 calibration points.
- After the calibration points are submitted, a query is sent to the probe asking how many calibration points are active, and the probe's response is displayed to the user. This must be dismissed by the user pressing a key--it does not time out.
- The device remains in "calibration mode" for the duration of this process until the user dismisses the response. (Previously the device was not in calibration mode during the waits between entering the midpoint and the lowpoint and between entering the lowpoint and the highpoint.)