### PR TITLE
Use Git commit hooks to get version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,19 +77,19 @@ $(BIN)/EEPROMTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/EEPROMTest.cpp
 $(BIN)/EnablePIDTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/EnablePIDTest.cpp
 	$(GPP_TEST) -o $(BIN)/EnablePIDTest.cpp.bin $(TEST)/EnablePIDTest.cpp -larduino
 
-$(BIN)/EthernetServerTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/EthernetServerTest.cpp
+$(BIN)/EthernetServerTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/EthernetServerTest.cpp $(SRC)/Version.h
 	$(GPP_TEST) -o $(BIN)/EthernetServerTest.cpp.bin $(TEST)/EthernetServerTest.cpp -larduino
 
 $(BIN)/EthernetTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/EthernetTest.cpp
 	$(GPP_TEST) -o $(BIN)/EthernetTest.cpp.bin $(TEST)/EthernetTest.cpp -larduino
 
-$(BIN)/JSONBuilderTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/JSONBuilderTest.cpp
+$(BIN)/JSONBuilderTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/JSONBuilderTest.cpp $(SRC)/Version.h
 	$(GPP_TEST) -o $(BIN)/JSONBuilderTest.cpp.bin $(TEST)/JSONBuilderTest.cpp -larduino
 
 $(BIN)/KeypadTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/KeypadTest.cpp
 	$(GPP_TEST) -o $(BIN)/KeypadTest.cpp.bin $(TEST)/KeypadTest.cpp -larduino
 
-$(BIN)/LiquidCrystalTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/LiquidCrystalTest.cpp
+$(BIN)/LiquidCrystalTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/LiquidCrystalTest.cpp $(SRC)/Version.h
 	$(GPP_TEST) -o $(BIN)/LiquidCrystalTest.cpp.bin $(TEST)/LiquidCrystalTest.cpp -larduino
 
 $(BIN)/MenuTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/MenuTest.cpp
@@ -152,7 +152,7 @@ $(BIN)/SeeTankIDTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SeeTankIDTest.cpp
 $(BIN)/SeeTempCalOffsetTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SeeTempCalOffsetTest.cpp
 	$(GPP_TEST) -o $(BIN)/SeeTempCalOffsetTest.cpp.bin $(TEST)/SeeTempCalOffsetTest.cpp -larduino
 
-$(BIN)/SeeVersionTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SeeVersionTest.cpp
+$(BIN)/SeeVersionTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SeeVersionTest.cpp $(SRC)/Version.h
 	$(GPP_TEST) -o $(BIN)/SeeVersionTest.cpp.bin $(TEST)/SeeVersionTest.cpp -larduino
 
 $(BIN)/SerialTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SerialTest.cpp
@@ -268,7 +268,7 @@ $(BIN)/ArduinoUnitTests.o: $(ARDUINO_CI)/unittest/ArduinoUnitTests.cpp
 $(BIN)/TC_util.o: $(SRC)/TC_util.cpp
 	g++ -c $(FLAGS) $(INCLUDE) -o $(BIN)/TC_util.o $(SRC)/TC_util.cpp
 
-$(BIN)/TankController.o: $(SRC)/TankController.cpp
+$(BIN)/TankController.o: $(SRC)/TankController.cpp $(SRC)/Version.h
 	g++ -c $(FLAGS) $(INCLUDE) -o $(BIN)/TankController.o $(SRC)/TankController.cpp
 
 $(BIN)/DataLogger_TC.o: $(SRC)/Devices/DataLogger_TC.cpp

--- a/extras/scripts/post-commit
+++ b/extras/scripts/post-commit
@@ -1,0 +1,2 @@
+version=`git describe --tags`
+echo "#define VERSION \"${version:0:15}+\"" > src/Version.h

--- a/extras/scripts/post-commit
+++ b/extras/scripts/post-commit
@@ -1,2 +1,3 @@
 version=`git describe --tags`
 echo "#define VERSION \"${version:0:15}+\"" > src/Version.h
+echo "const String gitVersion = '$version';" > extras/web_client/lib/model/version.dart

--- a/extras/scripts/post-commit
+++ b/extras/scripts/post-commit
@@ -1,3 +1,4 @@
 version=`git describe --tags`
-echo "#define VERSION \"${version:0:15}+\"" > src/Version.h
+version="${version:0:15}+"
+echo "#define VERSION \"$version\"" > src/Version.h
 echo "const String gitVersion = '$version';" > extras/web_client/lib/model/version.dart

--- a/extras/scripts/post-commit
+++ b/extras/scripts/post-commit
@@ -1,4 +1,5 @@
 version=`git describe --tags`
+version="$version                    "
 version="${version:0:15}+"
 echo "#define VERSION \"$version\"" > src/Version.h
 echo "const String gitVersion = '$version';" > extras/web_client/lib/model/version.dart

--- a/extras/scripts/pre-commit
+++ b/extras/scripts/pre-commit
@@ -1,3 +1,4 @@
+git add src/Version.h extras/web_client/lib/model/version.dart
 version=`git describe --tags`
 changes=`git diff | grep "+++" | grep -v "Version.h" | grep -v "version.dart" | wc -l | xargs`
 if [[ "$changes" == "0" ]]
@@ -8,4 +9,3 @@ else
 fi
 echo "#define VERSION \"$version\"" > src/Version.h
 echo "const String gitVersion = '$version';" > extras/web_client/lib/model/version.dart
-git add src/Version.h extras/web_client/lib/model/version.dart

--- a/extras/scripts/pre-commit
+++ b/extras/scripts/pre-commit
@@ -1,4 +1,5 @@
 version=`git describe --tags`
+version="$version                    "
 changes=`git diff | grep "+++" | grep -v "Version.h" | grep -v "version.dart" | wc -l | xargs`
 if [[ "$changes" == "0" ]]
 then

--- a/extras/scripts/pre-commit
+++ b/extras/scripts/pre-commit
@@ -8,4 +8,4 @@ else
 fi
 echo "#define VERSION \"$version\"" > src/Version.h
 echo "const String gitVersion = '$version';" > extras/web_client/lib/model/version.dart
-git add src/Version.h
+git add src/Version.h extras/web_client/lib/model/version.dart

--- a/extras/scripts/pre-commit
+++ b/extras/scripts/pre-commit
@@ -1,0 +1,9 @@
+version=`git describe --tags`
+changes=`git diff | grep "+++" | grep -v "src/Version.h" | wc -l | xargs`
+if [[ "$changes" == "0" ]]
+then
+  echo "#define VERSION \"${version:0:16}\"" > src/Version.h
+else
+  echo "#define VERSION \"${version:0:15}+\"" > src/Version.h
+fi
+git add src/Version.h

--- a/extras/scripts/pre-commit
+++ b/extras/scripts/pre-commit
@@ -1,4 +1,3 @@
-git add src/Version.h extras/web_client/lib/model/version.dart
 version=`git describe --tags`
 changes=`git diff | grep "+++" | grep -v "Version.h" | grep -v "version.dart" | wc -l | xargs`
 if [[ "$changes" == "0" ]]
@@ -9,3 +8,4 @@ else
 fi
 echo "#define VERSION \"$version\"" > src/Version.h
 echo "const String gitVersion = '$version';" > extras/web_client/lib/model/version.dart
+git add src/Version.h extras/web_client/lib/model/version.dart

--- a/extras/scripts/pre-commit
+++ b/extras/scripts/pre-commit
@@ -1,9 +1,11 @@
 version=`git describe --tags`
-changes=`git diff | grep "+++" | grep -v "src/Version.h" | wc -l | xargs`
+changes=`git diff | grep "+++" | grep -v "Version.h" | grep -v "version.dart" | wc -l | xargs`
 if [[ "$changes" == "0" ]]
 then
-  echo "#define VERSION \"${version:0:16}\"" > src/Version.h
+  version="${version:0:16}"
 else
-  echo "#define VERSION \"${version:0:15}+\"" > src/Version.h
+  version="${version:0:15}+"
 fi
+echo "#define VERSION \"$version\"" > src/Version.h
+echo "const String gitVersion = '$version';" > extras/web_client/lib/model/version.dart
 git add src/Version.h

--- a/extras/scripts/test.sh
+++ b/extras/scripts/test.sh
@@ -1,4 +1,6 @@
 #! /bin/bash
+(cd .git; mkdir -p hooks)
+cp extras/scripts/p*-commit .git/hooks/
 bundle config set --local path 'vendor/bundle'
 bundle install
 if [ -z "$1" ]; then

--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+(cd .git; mkdir -p hooks)
+cp extras/scripts/p*-commit .git/hooks/
 bundle config set --local path 'vendor/bundle'
 bundle install
 bundle exec arduino_ci.rb --min-free-space=5898 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )

--- a/extras/web_client/lib/components/app_drawer.dart
+++ b/extras/web_client/lib/components/app_drawer.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:tank_manager/model/app_data.dart';
 import 'package:tank_manager/model/tank.dart';
 import 'package:tank_manager/model/tc_interface.dart';
+import 'package:tank_manager/model/version.dart';
 
 class AppDrawer extends StatelessWidget {
   const AppDrawer({
@@ -40,50 +43,76 @@ class AppDrawer extends StatelessWidget {
     );
   }
 
+  Widget addTankButton(
+    TextEditingController nameController,
+    TextEditingController ipController,
+    AppData appData,
+  ) {
+    return Align(
+      alignment: Alignment.topRight,
+      child: FloatingActionButton(
+        onPressed: () async {
+          var newTank = Tank(nameController.text, ipController.text);
+          try {
+            await appData.addTank(newTank);
+          } catch (e) {
+            showAlertDialog(e.runtimeType.toString(), context);
+          }
+        },
+        tooltip: 'Add Tank',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Widget removeTankButton(
+    TextEditingController nameController,
+    TextEditingController ipController,
+    AppData appData,
+  ) {
+    return Align(
+      alignment: Alignment.topRight,
+      child: FloatingActionButton(
+        onPressed: () {
+          appData.removeTank(appData.currentTank);
+          appData.clearTank();
+        },
+        tooltip: 'Remove Tank',
+        child: const Icon(Icons.delete_sharp),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    var appData = AppData.instance;
+    AppData appData = AppData.instance;
     final ipController = TextEditingController();
     final nameController = TextEditingController();
     List<Widget> tiles = <Widget>[];
-    appData.readTankList();
+    unawaited(appData.readTankList()); // this doesn't await!
     for (var tank in appData.tankList) {
       tiles.add(tile(tank));
     }
     return Drawer(
       backgroundColor: Colors.grey.shade600,
-      child: ListView(
-        padding: EdgeInsets.zero,
-        children: [
-          drawerHeader(context),
-          ...tiles,
-          field(nameController, 'Name', 'Tank 99'),
-          field(ipController, 'IP', '000.000.000.000'),
-          Align(
-            alignment: Alignment.topRight,
-            child: FloatingActionButton(
-              onPressed: () async {
-                var newTank = Tank(nameController.text, ipController.text);
-                try {
-                  await appData.addTank(newTank);
-                } catch (e) {
-                  showAlertDialog(e.runtimeType.toString(), context);
-                }
-              },
-              tooltip: 'Add Tank',
-              child: const Icon(Icons.add),
+      child: Column(
+        children: <Widget>[
+          Expanded(
+            child: ListView(
+              padding: EdgeInsets.zero,
+              children: <Widget>[
+                drawerHeader(context),
+                ...tiles,
+                field(nameController, 'Name', 'Tank 99'),
+                field(ipController, 'IP', '000.000.000.000'),
+                addTankButton(nameController, ipController, appData),
+                removeTankButton(nameController, ipController, appData),
+              ],
             ),
           ),
-          Align(
-            alignment: Alignment.topRight,
-            child: FloatingActionButton(
-              onPressed: () {
-                appData.removeTank(appData.currentTank);
-                appData.clearTank();
-              },
-              tooltip: 'Remove Tank',
-              child: const Icon(Icons.delete_sharp),
-            ),
+          const Align(
+            alignment: FractionalOffset.bottomCenter,
+            child: Text(gitVersion),
           ),
         ],
       ),

--- a/extras/web_client/lib/model/version.dart
+++ b/extras/web_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = '23.7.0-3-ga38c54';
+const String gitVersion = '23.7.0';

--- a/extras/web_client/lib/model/version.dart
+++ b/extras/web_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = '23.7.0';
+const String gitVersion = '23.7.0-1-gc2a96f';

--- a/extras/web_client/lib/model/version.dart
+++ b/extras/web_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = '23.7.0';
+const String gitVersion = '23.7.0          ';

--- a/extras/web_client/lib/model/version.dart
+++ b/extras/web_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = '23.7.0+';
+const String gitVersion = '23.7.0-3-ga38c54';

--- a/extras/web_client/lib/model/version.dart
+++ b/extras/web_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = '23.7.0-1-gc2a96f';
+const String gitVersion = '23.7.0';

--- a/extras/web_client/lib/model/version.dart
+++ b/extras/web_client/lib/model/version.dart
@@ -1,0 +1,1 @@
+const String gitVersion = '23.7.0+';

--- a/src/Devices/LiquidCrystal_TC.cpp
+++ b/src/Devices/LiquidCrystal_TC.cpp
@@ -37,9 +37,7 @@ void LiquidCrystal_TC::splashScreen(const char* version) {
   clear();
   print(F("Tank Controller "));
   setCursor(0, 1);
-  print('v');
   print(version);
-  print(F(" loading"));
 }
 
 /**

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -21,8 +21,9 @@
 #include "TC_util.h"
 #include "UIState/MainMenu.h"
 #include "UIState/UIState.h"
+#include "Version.h"
 
-const char TANK_CONTROLLER_VERSION[] = "23.7.0 ";
+const char TANK_CONTROLLER_VERSION[] = VERSION;
 
 // ------------ Class Methods ------------
 /**

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.7.0-1-gc2a96f"
+#define VERSION "23.7.0"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.06.0-16-g0ca2"
+#define VERSION "23.7.0"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.7.0"
+#define VERSION "23.7.0-1-gc2a96f"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.7.0"
+#define VERSION "23.7.0          "

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.7.0-2-g0e22ad"
+#define VERSION "23.7.0-3-ga38c54"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.7.0-3-ga38c54"
+#define VERSION "23.7.0"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.7.0"
+#define VERSION "23.7.0-1-ge6e8a4"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,0 +1,1 @@
+#define VERSION "23.06.0-15-g585c"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.06.0-15-g585c"
+#define VERSION "23.06.0-16-g0ca2"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.7.0-1-ge6e8a4"
+#define VERSION "23.7.0-2-g0e22ad"

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -11,6 +11,7 @@
 #include "Devices/TemperatureControl.h"
 #include "SetTime.h"
 #include "TankController.h"
+#include "Version.h"
 
 unittest_setup() {
   GODMODE()->resetClock();
@@ -186,7 +187,7 @@ unittest(currentData) {
       "Content-Encoding: identity\r\n"
       "Content-Language: en-US\r\n"
       "Access-Control-Allow-Origin: *\r\n"
-      "Content-Length: 320\r\n"
+      "Content-Length: 329\r\n"
       "\r\n"
       "{"
       "\"pH\":8.125,"
@@ -205,7 +206,7 @@ unittest(currentData) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 0m 1s\","
-      "\"Version\":\"23.7.0 \""
+      "\"Version\":\"" VERSION "\""
       "}\r\n";
   assertEqual(expectedResponse, response);
   assertEqual(FINISHED, server->getState());

--- a/test/EthernetServerTest.cpp
+++ b/test/EthernetServerTest.cpp
@@ -206,7 +206,8 @@ unittest(currentData) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 0m 1s\","
-      "\"Version\":\"" VERSION "\""
+      "\"Version\":\"" VERSION
+      "\""
       "}\r\n";
   assertEqual(expectedResponse, response);
   assertEqual(FINISHED, server->getState());

--- a/test/JSONBuilderTest.cpp
+++ b/test/JSONBuilderTest.cpp
@@ -48,7 +48,8 @@ unittest(currentData) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 0m 1s\","
-      "\"Version\":\"" VERSION "\""
+      "\"Version\":\"" VERSION
+      "\""
       "}";
   assertEqual(expected, text);
 }

--- a/test/JSONBuilderTest.cpp
+++ b/test/JSONBuilderTest.cpp
@@ -9,6 +9,8 @@
 #include "Devices/TempProbe_TC.h"
 #include "Devices/TemperatureControl.h"
 #include "TankController.h"
+#include "Version.h"
+
 /**
  * Test correctness of JSON output from JSONBuilder
  */
@@ -46,7 +48,7 @@ unittest(currentData) {
       "\"PID\":\"ON\","
       "\"TankID\":0,"
       "\"Uptime\":\"0d 0h 0m 1s\","
-      "\"Version\":\"23.7.0 \""
+      "\"Version\":\"" VERSION "\""
       "}";
   assertEqual(expected, text);
 }

--- a/test/LiquidCrystalTest.cpp
+++ b/test/LiquidCrystalTest.cpp
@@ -5,6 +5,7 @@
 
 #include "Devices/LiquidCrystal_TC.h"
 #include "TankController.h"
+#include "Version.h"
 
 unittest(loop) {
   TankController* tank = TankController::instance();
@@ -19,10 +20,7 @@ unittest(loop) {
   assertEqual(16, lines.at(0).length());
   assertEqual(16, lines.at(1).length());
   assertEqual("Tank Controller ", lines.at(0));
-  assertEqual(
-      "v"  // separating the 'v' allows a word-search to find the number
-      "23.7.0  loading",
-      lines.at(1));
+  assertEqual(VERSION, lines.at(1));
 }
 
 unittest(writeLine) {

--- a/test/SeeVersionTest.cpp
+++ b/test/SeeVersionTest.cpp
@@ -5,6 +5,7 @@
 #include "../src/Devices/LiquidCrystal_TC.h"
 #include "../src/TankController.h"
 #include "../src/UIState/SeeVersion.h"
+#include "Version.h"
 
 unittest(testOutput) {
   TankController* tc = TankController::instance();
@@ -17,7 +18,7 @@ unittest(testOutput) {
   // Test the output
   tc->loop(false);
   assertEqual("Software Version", display->getLines().at(0));
-  assertEqual("23.7.0          ", display->getLines().at(1));
+  assertEqual(VERSION, display->getLines().at(1));
   // Return to mainMenu
   Keypad_TC::instance()->_getPuppet()->push_back('D');
   tc->loop(false);


### PR DESCRIPTION
This adds pre-commit and post-commit scripts to the scripts directory. These scripts are copied to `.git/hooks` by the test.sh and testAndBuild.sh scripts where they are run automatically. 

Before a commit the code uses `git describe --tags` to get a version description. This version description is then placed in two files, `src/Version.h` and `extras/web_client/lib/model/version.dart`. The code then uses these files as the version to display on the device and in the web client (at the bottom of the drawer).

We have a self-referential problem: To put the version in a file that is part of version control, it must be edited before a commit. But the description give by Git will be of the status before the commit (or a description of the _prior_ commit) and we really want to have the version reflect current commit. To make this work you need to commit and tag then do another commit. That way the description will be of the tag alone. 

But then there could be other changes! To address this problem we look at the modified files and if there are changes to anything other than the respective version files then we append a '+' to the version description. If this is not present, then the version description is accurate. 

As a general practice, one should do the initial tag locally (not pushed) and then retag the second commit and move the tag. Then push the second commit and use it for the release.

Fix #410.
