### PR TITLE
Ensure type is known for AppData and TcInterface singletons

### DIFF
--- a/extras/web_client/lib/components/app_drawer.dart
+++ b/extras/web_client/lib/components/app_drawer.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tank_manager/model/app_data.dart';
 import 'package:tank_manager/model/tank.dart';
@@ -87,7 +88,7 @@ class AppDrawer extends StatelessWidget {
     final ipController = TextEditingController();
     final nameController = TextEditingController();
     List<Widget> tiles = <Widget>[];
-    appData.readTankList();
+    unawaited(appData.readTankList()); // TODO
     for (var tank in appData.tankList) {
       tiles.add(tile(tank));
     }
@@ -142,19 +143,22 @@ class AppDrawer extends StatelessWidget {
     );
   }
 
-  Widget tile(var selected) {
+  Future<void> updateDisplay() async {
     var appData = AppData.instance();
     var tcInterface = TcInterface.instance();
+    String value = await tcInterface.get(appData.currentTank.ip, 'display');
+    appData.display = value; // setter notifies listeners of change
+  }
+
+  Widget tile(var selected) {
     return ListTile(
       title: Text(
         selected.name,
         style: const TextStyle(color: Colors.white),
       ),
       onTap: () {
-        appData.currentTank = selected;
-        tcInterface.get(appData.currentTank.ip, 'display').then((value) {
-          appData.display = value;
-        });
+        AppData.instance().currentTank = selected;
+        unawaited(updateDisplay());
         Navigator.pop(context);
       },
     );

--- a/extras/web_client/lib/components/app_drawer.dart
+++ b/extras/web_client/lib/components/app_drawer.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:tank_manager/model/app_data.dart';
 import 'package:tank_manager/model/tank.dart';
@@ -85,11 +83,11 @@ class AppDrawer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    AppData appData = AppData.instance;
+    var appData = AppData.instance();
     final ipController = TextEditingController();
     final nameController = TextEditingController();
     List<Widget> tiles = <Widget>[];
-    unawaited(appData.readTankList()); // this doesn't await!
+    appData.readTankList();
     for (var tank in appData.tankList) {
       tiles.add(tile(tank));
     }
@@ -145,8 +143,8 @@ class AppDrawer extends StatelessWidget {
   }
 
   Widget tile(var selected) {
-    var appData = AppData.instance;
-    var tcInterface = TcInterface.instance;
+    var appData = AppData.instance();
+    var tcInterface = TcInterface.instance();
     return ListTile(
       title: Text(
         selected.name,

--- a/extras/web_client/lib/components/app_drawer.dart
+++ b/extras/web_client/lib/components/app_drawer.dart
@@ -88,7 +88,6 @@ class AppDrawer extends StatelessWidget {
     final ipController = TextEditingController();
     final nameController = TextEditingController();
     List<Widget> tiles = <Widget>[];
-    unawaited(appData.readTankList()); // TODO
     for (var tank in appData.tankList) {
       tiles.add(tile(tank));
     }

--- a/extras/web_client/lib/components/keypad.dart
+++ b/extras/web_client/lib/components/keypad.dart
@@ -53,8 +53,8 @@ class Keypad extends StatelessWidget {
   }
 
   Widget button(BuildContext context, var label, var color) {
-    var appData = AppData.instance;
-    var tcInterface = TcInterface.instance;
+    var appData = AppData.instance();
+    var tcInterface = TcInterface.instance();
     return Container(
       padding: const EdgeInsets.all(8),
       decoration: BoxDecoration(

--- a/extras/web_client/lib/components/keypad.dart
+++ b/extras/web_client/lib/components/keypad.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tank_manager/model/tc_interface.dart';
 import 'package:tank_manager/model/app_data.dart';
@@ -52,9 +53,13 @@ class Keypad extends StatelessWidget {
     ];
   }
 
+  Future<void> sendKeypress(String ip, String path) async {
+    String value = await TcInterface.instance().post(ip, path);
+    AppData.instance().display = value;
+  }
+
   Widget button(BuildContext context, var label, var color) {
     var appData = AppData.instance();
-    var tcInterface = TcInterface.instance();
     return Container(
       padding: const EdgeInsets.all(8),
       decoration: BoxDecoration(
@@ -69,11 +74,7 @@ class Keypad extends StatelessWidget {
         ),
         onPressed: () {
           if (appData.currentTank.isNotEmpty()) {
-            tcInterface
-                .post(appData.currentTank.ip, 'key?value=$label')
-                .then((value) {
-              appData.display = value;
-            });
+            unawaited(sendKeypress(appData.currentTank.ip, 'key?value=$label'));
           }
         },
         child: Text(label),

--- a/extras/web_client/lib/components/nav_bar.dart
+++ b/extras/web_client/lib/components/nav_bar.dart
@@ -32,7 +32,7 @@ class NavBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var appData = AppData.instance;
+    var appData = AppData.instance();
     int currentIndex = appData.currentIndex;
     return BottomNavigationBar(
       currentIndex: currentIndex,
@@ -45,7 +45,7 @@ class NavBar extends StatelessWidget {
   }
 
   void onTabTapped(int index) {
-    var appData = AppData.instance;
+    var appData = AppData.instance();
     appData.currentIndex = index;
     if (items[index].label == 'Keypad') {
       appData.refreshDisplay();

--- a/extras/web_client/lib/components/nav_bar.dart
+++ b/extras/web_client/lib/components/nav_bar.dart
@@ -48,10 +48,10 @@ class NavBar extends StatelessWidget {
     var appData = AppData.instance();
     appData.currentIndex = index;
     if (items[index].label == 'Keypad') {
-      appData.refreshDisplay();
+      unawaited(appData.refreshDisplay()); // TODO
     }
     if (items[index].label == 'Current Data') {
-      appData.refreshCurrentData();
+      unawaited(appData.refreshCurrentData()); // TODO
     }
     if (items[index].label == 'Files') {
       unawaited(appData.refreshFiles());

--- a/extras/web_client/lib/components/nav_bar.dart
+++ b/extras/web_client/lib/components/nav_bar.dart
@@ -48,10 +48,10 @@ class NavBar extends StatelessWidget {
     var appData = AppData.instance();
     appData.currentIndex = index;
     if (items[index].label == 'Keypad') {
-      unawaited(appData.refreshDisplay()); // TODO
+      unawaited(appData.refreshDisplay()); // this will notify listeners
     }
     if (items[index].label == 'Current Data') {
-      unawaited(appData.refreshCurrentData()); // TODO
+      unawaited(appData.refreshCurrentData()); // this will notify listeners
     }
     if (items[index].label == 'Files') {
       unawaited(appData.refreshFiles());

--- a/extras/web_client/lib/main.dart
+++ b/extras/web_client/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:tank_manager/model/app_data.dart';
 
 Future<void> main() async {
-  await AppData.instance.readTankList();
+  await AppData.instance().readTankList();
   runApp(const MyApp());
 }
 
@@ -14,7 +14,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<AppData>.value(
-      value: AppData.instance,
+      value: AppData.instance(),
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
         title: 'Tank Manager',

--- a/extras/web_client/lib/model/app_data.dart
+++ b/extras/web_client/lib/model/app_data.dart
@@ -8,9 +8,9 @@ import 'dart:async';
 class AppData with ChangeNotifier {
   static AppData? _instance;
 
-  static get instance {
+  static AppData instance() {
     _instance ??= AppData();
-    return _instance;
+    return _instance!;
   }
 
   AppData() {
@@ -43,7 +43,7 @@ class AppData with ChangeNotifier {
 
   Future<void> refreshDisplay() async {
     if (currentTank.isNotEmpty()) {
-      var tcInterface = TcInterface.instance;
+      var tcInterface = TcInterface.instance();
       display = await tcInterface.get(currentTank.ip, 'display');
     } else {
       display = '';
@@ -55,7 +55,7 @@ class AppData with ChangeNotifier {
     if (currentTank.isEmpty()) {
       currentData = jsonDecode('{"Error: Choose tank from menu":""}');
     } else {
-      var tcInterface = TcInterface.instance;
+      var tcInterface = TcInterface.instance();
       var value = await tcInterface.get(currentTank.ip, 'data');
       currentData = jsonDecode(value);
     }
@@ -65,7 +65,7 @@ class AppData with ChangeNotifier {
     if (currentTank.isEmpty()) {
       _files = jsonDecode('{"Error: Choose tank from menu":""}');
     } else {
-      var tcInterface = TcInterface.instance;
+      var tcInterface = TcInterface.instance();
       // wait 15 seconds (the default of 5 seconds could be too little)
       var value = await tcInterface.get(currentTank.ip, 'rootdir', 15);
       while (value.substring(value.length - 1) == '\n') {
@@ -82,7 +82,7 @@ class AppData with ChangeNotifier {
   Future<void> addTank(tank) async {
     // make a call to the device to see if it exists
     // ignore result
-    await TcInterface.instance.get(tank.ip, 'data');
+    await TcInterface.instance().get(tank.ip, 'data');
     _tankList.add(tank);
     unawaited(refreshDisplay());
     notifyListeners();

--- a/extras/web_client/lib/model/tc_interface.dart
+++ b/extras/web_client/lib/model/tc_interface.dart
@@ -3,17 +3,22 @@ import 'package:http/http.dart' as http;
 abstract class TcInterface {
   static TcInterface? _instance;
 
-  static get instance {
+  static TcInterface instance() {
     _instance ??= TcRealInterface();
-    return _instance;
+    return _instance!;
   }
 
   static void useMock() {
     _instance = TcMockInterface();
   }
+
+  Future<String> get(String ip, String path, [int timeout = 5]);
+  Future<String> post(String ip, String path, [int timeout = 5]);
+  Future<String> put(String ip, String path);
 }
 
 class TcMockInterface extends TcInterface {
+  @override
   Future<String> get(String ip, String path, [int timeout = 5]) async {
     if (ip == '127.0.0.1') {
       throw ('Invalid IP Address in TcMockInterface');
@@ -27,16 +32,19 @@ class TcMockInterface extends TcInterface {
     return 'pH=7.352   7.218\nT=10.99 C 11.00$path';
   }
 
-  Future<String> post(var value, String path, [int timeout = 5]) async {
+  @override
+  Future<String> post(String ip, String path, [int timeout = 5]) async {
     return 'pH=7.352   7.218\nT=10.99 C 11.00${path.substring(path.length - 1)}';
   }
 
-  Future<String> put(var value, String path) async {
+  @override
+  Future<String> put(String ip, String path) async {
     return '{"IPAddress":"172.27.5.150","MAC":"90:A2:DA:0F:45:C0","FreeMemory":"3791 bytes","GoogleSheetInterval":10,"LogFile":"20220722.csv","PHSlope":"22","Kp":9000.4,"Ki":0.0,"Kd":0.0,"PID":"ON","TankID":3,"Uptime":"0d 0h 1m 7s","Version":"22.04.1"}';
   }
 }
 
 class TcRealInterface extends TcInterface {
+  @override
   Future<String> get(String ip, String path, [int timeout = 5]) async {
     var uri = 'http://$ip/api/1/$path';
     var future = http.get(Uri.parse(uri));
@@ -48,7 +56,8 @@ class TcRealInterface extends TcInterface {
     return subString;
   }
 
-  Future<String> post(var ip, var path, [int timeout = 5]) async {
+  @override
+  Future<String> post(String ip, var path, [int timeout = 5]) async {
     var uri = 'http://$ip/api/1/$path';
     final future = http.post(Uri.parse(uri));
     var response = await future.timeout(Duration(seconds: timeout));
@@ -59,6 +68,7 @@ class TcRealInterface extends TcInterface {
     return subString;
   }
 
+  @override
   Future<String> put(String ip, String path) async {
     var uri = 'http://$ip/api/1/$path';
     final future = http.put(Uri.parse(uri));

--- a/extras/web_client/lib/model/version.dart
+++ b/extras/web_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = '23.7.0-4-g80088a';
+const String gitVersion = '23.7.0-2-g311726';

--- a/extras/web_client/lib/model/version.dart
+++ b/extras/web_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = '23.7.0-2-g311726';
+const String gitVersion = '23.7.0-3-g5208b2';

--- a/extras/web_client/lib/model/version.dart
+++ b/extras/web_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = '23.7.0-3-g5208b2';
+const String gitVersion = '23.7.0-4-gca1360';

--- a/extras/web_client/lib/view/current_data_page.dart
+++ b/extras/web_client/lib/view/current_data_page.dart
@@ -50,7 +50,7 @@ class CurrentData extends StatelessWidget {
                   TextFormField(
                     initialValue: value.toString(),
                     onFieldSubmitted: (val) {
-                      TcInterface.instance
+                      TcInterface.instance()
                           .put(
                         '${appData.currentData["IPAddress"]}',
                         'data?${key.toString()}=$val',

--- a/extras/web_client/test/app_data_test.dart
+++ b/extras/web_client/test/app_data_test.dart
@@ -9,7 +9,7 @@ import 'package:tank_manager/model/tc_interface.dart';
 void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   SharedPreferences.setMockInitialValues({});
-  var appData = AppData.instance;
+  var appData = AppData.instance();
 
   setUp(() {
     TcInterface.useMock();

--- a/extras/web_client/test/tc_interface_test.dart
+++ b/extras/web_client/test/tc_interface_test.dart
@@ -3,7 +3,7 @@ import 'package:tank_manager/model/tc_interface.dart';
 
 void main() {
   TcInterface.useMock();
-  var tcInterface = TcInterface.instance;
+  var tcInterface = TcInterface.instance();
   test('Post', () async {
     var post = await tcInterface.post('192.168.0.1', 'key?value=4');
     expect(

--- a/extras/web_client/test/widget_test.dart
+++ b/extras/web_client/test/widget_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   tearDown(() {
     // Reset so that we no longer have a tank
-    AppData.instance.clearTank();
+    AppData.instance().clearTank();
   });
 
   testWidgets('Keypad buttons work as expected', (WidgetTester tester) async {
@@ -37,7 +37,7 @@ void main() {
     ];
 
     // Create a tank
-    var appData = AppData.instance;
+    var appData = AppData.instance();
     appData.currentTank = Tank('test_tank', '192.168.0.1');
 
     // Force button visibility for tester
@@ -61,7 +61,7 @@ void main() {
     await tester.pumpWidget(const MyApp());
 
     // Create a tank
-    var appData = AppData.instance;
+    var appData = AppData.instance();
     appData.currentTank = Tank('test_tank', '192.168.0.1');
 
     // Verify Current Data is not displayed
@@ -82,7 +82,7 @@ void main() {
     await tester.pumpWidget(const MyApp());
 
     // Create a tank
-    var appData = AppData.instance;
+    var appData = AppData.instance();
     appData.currentTank = Tank('test_tank', '192.168.0.1');
 
     // Verify files are not displayed

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.7.0-2-g311726"
+#define VERSION "23.7.0-3-g5208b2"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.7.0-3-g5208b2"
+#define VERSION "23.7.0-4-gca1360"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.7.0-4-g80088a"
+#define VERSION "23.7.0-2-g311726"


### PR DESCRIPTION
We were using a property getter for a singleton that starts out as null, so the type was simply Object. By switching to a method getter we can specify the type as not null and this provides better type information (and highlights several "discarded futures" problems that already exist and should be addressed in the future).