### PR TITLE
pH Calibration interface changes

### DIFF
--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -3,6 +3,6 @@
 cp extras/scripts/p*-commit .git/hooks/
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5790 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
+bundle exec arduino_ci.rb --min-free-space=5792 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
 result="${PIPESTATUS[0]}"
 exit "$result"

--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -3,6 +3,6 @@
 cp extras/scripts/p*-commit .git/hooks/
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5792 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
+bundle exec arduino_ci.rb --min-free-space=5696 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
 result="${PIPESTATUS[0]}"
 exit "$result"

--- a/extras/web_client/lib/model/version.dart
+++ b/extras/web_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = '23.7.2          ';
+const String gitVersion = '23.7.2-1-gaac6a+';

--- a/src/UIState/PHCalibrationHigh.cpp
+++ b/src/UIState/PHCalibrationHigh.cpp
@@ -5,14 +5,14 @@
 
 #include "Devices/LiquidCrystal_TC.h"
 #include "Devices/PHProbe.h"
-#include "SeePHCalibration.h"
+#include "PHCalibrationLow.h"
 #include "Wait.h"
 
 void PHCalibrationHigh::setValue(float value) {
   PHProbe::instance()->setHighpointCalibration(value);
   char buffer[17];
-  strscpy_P(buffer, F("New High="), sizeof(buffer));
-  floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New High=12.345"
+  strscpy_P(buffer, F("High = "), sizeof(buffer));
+  floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "High = 12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-  this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc, true)));
+  this->setNextState(new Wait(tc, 3000, new PHCalibrationLow(tc)));
 }

--- a/src/UIState/PHCalibrationHigh.h
+++ b/src/UIState/PHCalibrationHigh.h
@@ -7,6 +7,10 @@
 #include "PHCalibration.h"
 #include "TC_util.h"  // For strnlen
 
+/**
+ * @brief Set high/basic buffer pH value as part of a 3-point calibration
+ *
+ */
 class PHCalibrationHigh : public PHCalibration {
 public:
   PHCalibrationHigh(TankController* tc) : PHCalibration(tc) {
@@ -15,7 +19,7 @@ public:
     return F("PHCalibrationHigh");
   }
   const __FlashStringHelper* prompt() override {
-    return F("pH-Highpoint");
+    return F("High buffer pH");
   };
   void setValue(float value) override;
 };

--- a/src/UIState/PHCalibrationLow.cpp
+++ b/src/UIState/PHCalibrationLow.cpp
@@ -5,7 +5,6 @@
 
 #include "Devices/LiquidCrystal_TC.h"
 #include "Devices/PHProbe.h"
-#include "PHCalibrationHigh.h"
 #include "SeePHCalibration.h"
 #include "UIState.h"
 #include "Wait.h"
@@ -13,12 +12,17 @@
 void PHCalibrationLow::setValue(float value) {
   PHProbe::instance()->setLowpointCalibration(value);
   char buffer[17];
-  strscpy_P(buffer, F("New Low = "), sizeof(buffer));
-  floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New Low = 12.345"
+  strscpy_P(buffer, F("Low = "), sizeof(buffer));
+  floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "Low = 12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-  if (this->numberOfCalibrationPoints > 2) {
-    this->setNextState(new Wait(tc, 3000, new PHCalibrationHigh(tc)));
-  } else {
-    this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc, true)));
-  }
+  this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc, true)));
+}
+
+void PHCalibrationLower::setValue(float value) {
+  PHProbe::instance()->setLowpointCalibration(value);
+  char buffer[17];
+  strscpy_P(buffer, F("Lower = "), sizeof(buffer));
+  floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "Lower = 12.345"
+  LiquidCrystal_TC::instance()->writeLine(buffer, 1);
+  this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc, true)));
 }

--- a/src/UIState/PHCalibrationLow.h
+++ b/src/UIState/PHCalibrationLow.h
@@ -7,19 +7,36 @@
 #include "PHCalibration.h"
 #include "TC_util.h"  // For strnlen
 
+/**
+ * @brief Set low/acidic buffer pH value as part of a 3-point calibration
+ *
+ */
 class PHCalibrationLow : public PHCalibration {
 public:
-  PHCalibrationLow(TankController* tc, int numberOfCalibrationPoints = 3) : PHCalibration(tc) {
-    this->numberOfCalibrationPoints = numberOfCalibrationPoints;
+  PHCalibrationLow(TankController* tc) : PHCalibration(tc) {
   }
   const __FlashStringHelper* name() override {
     return F("PHCalibrationLow");
   }
   const __FlashStringHelper* prompt() override {
-    return F("pH-Lowpoint");
+    return F("Low buffer pH");
   };
   void setValue(float value) override;
+};
 
-private:
-  int numberOfCalibrationPoints = 3;
+/**
+ * @brief Set low/acidic buffer pH value as part of a 2-point calibration
+ *
+ */
+class PHCalibrationLower : public PHCalibration {
+public:
+  PHCalibrationLower(TankController* tc) : PHCalibration(tc) {
+  }
+  const __FlashStringHelper* name() override {
+    return F("PHCalibrationLower");
+  }
+  const __FlashStringHelper* prompt() override {
+    return F("Lower buffer pH");
+  };
+  void setValue(float value) override;
 };

--- a/src/UIState/PHCalibrationMid.cpp
+++ b/src/UIState/PHCalibrationMid.cpp
@@ -5,6 +5,7 @@
 
 #include "Devices/LiquidCrystal_TC.h"
 #include "Devices/PHProbe.h"
+#include "PHCalibrationHigh.h"
 #include "PHCalibrationLow.h"
 #include "SeePHCalibration.h"
 #include "UIState.h"
@@ -13,12 +14,29 @@
 void PHCalibrationMid::setValue(float value) {
   PHProbe::instance()->setMidpointCalibration(value);
   char buffer[17];
-  strscpy_P(buffer, F("New Mid = "), sizeof(buffer));
-  floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "New Mid = 12.345"
+  strscpy_P(buffer, F("Mid = "), sizeof(buffer));
+  floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "Mid = 12.345"
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-  if (this->numberOfCalibrationPoints > 1) {
-    this->setNextState(new Wait(tc, 3000, new PHCalibrationLow(tc, this->numberOfCalibrationPoints)));
-  } else {
-    this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc, true)));
-  }
+  // Standard chemistry practice seems to be to set mid -> low -> high. However, mid -> high -> low has the advantage
+  // that if the calibrator neglects to replace the probe into the tank after calibration, it will be in a basic
+  // solution and the CO2 bubbler will remain off.
+  this->setNextState(new Wait(tc, 3000, new PHCalibrationHigh(tc)));
+}
+
+void PHCalibrationHigher::setValue(float value) {
+  PHProbe::instance()->setMidpointCalibration(value);
+  char buffer[17];
+  strscpy_P(buffer, F("Higher = "), sizeof(buffer));
+  floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "Higher = 12.345"
+  LiquidCrystal_TC::instance()->writeLine(buffer, 1);
+  this->setNextState(new Wait(tc, 3000, new PHCalibrationLower(tc)));
+}
+
+void PHCalibrationOnly::setValue(float value) {
+  PHProbe::instance()->setMidpointCalibration(value);
+  char buffer[17];
+  strscpy_P(buffer, F("Buffer = "), sizeof(buffer));
+  floattostrf(value, 5, 3, buffer + strnlen(buffer, sizeof(buffer)), 7);  // "Buffer = 12.345"
+  LiquidCrystal_TC::instance()->writeLine(buffer, 1);
+  this->setNextState(new Wait(tc, 3000, new SeePHCalibration(tc, true)));
 }

--- a/src/UIState/PHCalibrationMid.h
+++ b/src/UIState/PHCalibrationMid.h
@@ -7,19 +7,54 @@
 #include "PHCalibration.h"
 #include "TC_util.h"  // For strnlen
 
+/**
+ * @brief Set mid/neutral buffer pH value as part of a 3-point calibration
+ *
+ */
 class PHCalibrationMid : public PHCalibration {
 public:
-  PHCalibrationMid(TankController* tc, int numberOfCalibrationPoints = 3) : PHCalibration(tc) {
-    this->numberOfCalibrationPoints = numberOfCalibrationPoints;
+  PHCalibrationMid(TankController* tc) : PHCalibration(tc) {
   }
   const __FlashStringHelper* name() override {
     return F("PHCalibrationMid");
   }
   const __FlashStringHelper* prompt() override {
-    return F("pH-Midpoint");
+    return F("Mid buffer pH");
   };
   void setValue(float value) override;
+};
 
-private:
-  int numberOfCalibrationPoints = 3;
+/**
+ * @brief Set mid/neutral buffer pH value as part of a 2-point calibration. We're using the comparative "higher" for the
+ * sake of students who have trouble remembering which of two buffers is the "mid" one.
+ *
+ */
+class PHCalibrationHigher : public PHCalibration {
+public:
+  PHCalibrationHigher(TankController* tc) : PHCalibration(tc) {
+  }
+  const __FlashStringHelper* name() override {
+    return F("PHCalibrationHigher");
+  }
+  const __FlashStringHelper* prompt() override {
+    return F("Higher buffer pH");
+  };
+  void setValue(float value) override;
+};
+
+/**
+ * @brief Set buffer pH value for a 1-point calibration.
+ *
+ */
+class PHCalibrationOnly : public PHCalibration {
+public:
+  PHCalibrationOnly(TankController* tc) : PHCalibration(tc) {
+  }
+  const __FlashStringHelper* name() override {
+    return F("PHCalibrationOnly");
+  }
+  const __FlashStringHelper* prompt() override {
+    return F("Buffer pH");
+  };
+  void setValue(float value) override;
 };

--- a/src/UIState/PHCalibrationPrompt.cpp
+++ b/src/UIState/PHCalibrationPrompt.cpp
@@ -12,10 +12,18 @@
 
 void PHCalibrationPrompt::setValue(float value) {
   char buffer[17];
-  if (value == 1 || value == 2 || value == 3) {
-    snprintf_P(buffer, sizeof(buffer), PSTR("%i-pt pH calib..."), (int)value);
+  if (value == 1) {
+    strscpy_P(buffer, F("1-pt pH calib..."), sizeof(buffer));
     LiquidCrystal_TC::instance()->writeLine(buffer, 1);
-    this->setNextState(new Wait(tc, 2000, new PHCalibrationMid(tc, value)));
+    this->setNextState(new Wait(tc, 2000, new PHCalibrationOnly(tc)));
+  } else if (value == 2) {
+    strscpy_P(buffer, F("2-pt pH calib..."), sizeof(buffer));
+    LiquidCrystal_TC::instance()->writeLine(buffer, 1);
+    this->setNextState(new Wait(tc, 2000, new PHCalibrationHigher(tc)));
+  } else if (value == 3) {
+    strscpy_P(buffer, F("3-pt pH calib..."), sizeof(buffer));
+    LiquidCrystal_TC::instance()->writeLine(buffer, 1);
+    this->setNextState(new Wait(tc, 2000, new PHCalibrationMid(tc)));
   } else {
     strscpy_P(buffer, F("Invalid entry"), sizeof(buffer));
     LiquidCrystal_TC::instance()->writeLine(buffer, 1);

--- a/src/UIState/SeePHCalibration.cpp
+++ b/src/UIState/SeePHCalibration.cpp
@@ -6,11 +6,20 @@
 
 #include "Devices/LiquidCrystal_TC.h"
 #include "Devices/PHProbe.h"
+#include "MainMenu.h"
+
+SeePHCalibration::SeePHCalibration(TankController* tc, bool inCalibration) : UIState(tc) {
+  endTime = millis() + 60000;
+  this->inCalibration = inCalibration;
+}
 
 void SeePHCalibration::loop() {
   char buffer[20];
   PHProbe::instance()->getCalibration(buffer, sizeof(buffer));
   LiquidCrystal_TC::instance()->writeLine(buffer, 1);
+  if (endTime <= millis()) {
+    this->setNextState(new MainMenu(tc));
+  }
 }
 
 void SeePHCalibration::start() {

--- a/src/UIState/SeePHCalibration.h
+++ b/src/UIState/SeePHCalibration.h
@@ -8,9 +8,7 @@
 
 class SeePHCalibration : public UIState {
 public:
-  SeePHCalibration(TankController* tc, bool inCalibration = false) : UIState(tc) {
-    this->inCalibration = inCalibration;
-  }
+  SeePHCalibration(TankController* tc, bool inCalibration = false);
   bool isInCalibration() override {
     return inCalibration;
   }
@@ -24,5 +22,6 @@ public:
   };
 
 private:
+  uint32_t endTime = 0;
   bool inCalibration;
 };

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "23.7.2          "
+#define VERSION "23.7.2-1-gaac6a+"

--- a/test/GetTimeTest.cpp
+++ b/test/GetTimeTest.cpp
@@ -9,7 +9,6 @@
 #include "Devices/TempProbe_TC.h"
 #include "Devices/TemperatureControl.h"
 #include "TankController.h"
-#include "UIState/PHCalibrationMid.h"
 
 EthernetClient *pClient;
 GodmodeState *state = GODMODE();

--- a/test/PHCalibrationHighTest.cpp
+++ b/test/PHCalibrationHighTest.cpp
@@ -15,14 +15,16 @@ unittest(test) {
   test->setValue(12.345);
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("New High=12.345 ", lines[1]);
+  assertEqual("High = 12.345   ", lines[1]);
   assertEqual("PHCalibrationHigh", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
-  delay(3000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
-  tc->loop(false);  // updateState to SeePHCalibration
-  assertEqual("SeePHCalibration", tc->stateName());
+  delay(2000);
+  assertTrue(tc->isInCalibration());
+  delay(1000);
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationLow
+  tc->loop(false);  // updateState to PHCalibrationLow
+  assertEqual("PHCalibrationLow", tc->stateName());
   assertTrue(tc->isInCalibration());
 }
 

--- a/test/PHCalibrationLowTest.cpp
+++ b/test/PHCalibrationLowTest.cpp
@@ -7,18 +7,20 @@
 
 unittest(twoPointLow) {
   TankController* tc = TankController::instance();
-  PHCalibrationLow* test = new PHCalibrationLow(tc, 2);
+  PHCalibrationLower* test = new PHCalibrationLower(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // setValue
   test->setValue(12.345);
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("New Low = 12.345", lines[1]);
-  assertEqual("PHCalibrationLow", tc->stateName());
+  assertEqual("Lower = 12.345  ", lines[1]);
+  assertEqual("PHCalibrationLower", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
-  delay(3000);
+  delay(2000);
+  assertTrue(tc->isInCalibration());
+  delay(1000);
   tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
   tc->loop(false);  // updateState to SeePHCalibration
   assertEqual("SeePHCalibration", tc->stateName());
@@ -27,21 +29,23 @@ unittest(twoPointLow) {
 
 unittest(threePointLow) {
   TankController* tc = TankController::instance();
-  PHCalibrationLow* test = new PHCalibrationLow(tc, 3);
+  PHCalibrationLow* test = new PHCalibrationLow(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // setValue
   test->setValue(12.345);
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("New Low = 12.345", lines[1]);
+  assertEqual("Low = 12.345    ", lines[1]);
   assertEqual("PHCalibrationLow", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
-  delay(3000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationHigh
-  tc->loop(false);  // updateState to PHCalibrationHigh
-  assertEqual("PHCalibrationHigh", tc->stateName());
+  delay(2000);
+  assertTrue(tc->isInCalibration());
+  delay(1000);
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
+  tc->loop(false);  // updateState to SeePHCalibration
+  assertEqual("SeePHCalibration", tc->stateName());
   assertTrue(tc->isInCalibration());
 }
 

--- a/test/PHCalibrationMidTest.cpp
+++ b/test/PHCalibrationMidTest.cpp
@@ -15,7 +15,7 @@ unittest(onePointMid) {
   assertEqual(7.125, pH);
 
   std::vector<String> lines;
-  PHCalibrationMid *test = new PHCalibrationMid(tc, 1);
+  PHCalibrationOnly *test = new PHCalibrationOnly(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   lines = LiquidCrystal_TC::instance()->getLines();
@@ -30,11 +30,13 @@ unittest(onePointMid) {
   test->setValue(12.345);
   // during the delay we showed the new value
   lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("New Mid = 12.345", lines.at(1));
-  assertEqual("PHCalibrationMid", tc->stateName());
+  assertEqual("Buffer = 12.345 ", lines.at(1));
+  assertEqual("PHCalibrationOnly", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
-  delay(3000);
+  delay(2000);
+  assertTrue(tc->isInCalibration());
+  delay(1000);
   tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to SeePHCalibration
   tc->loop(false);  // updateState to SeePHCalibration
   assertEqual("SeePHCalibration", tc->stateName());
@@ -50,7 +52,7 @@ unittest(twoPointMid) {
   assertEqual(7.125, pH);
 
   std::vector<String> lines;
-  PHCalibrationMid *test = new PHCalibrationMid(tc, 2);
+  PHCalibrationHigher *test = new PHCalibrationHigher(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   lines = LiquidCrystal_TC::instance()->getLines();
@@ -65,14 +67,53 @@ unittest(twoPointMid) {
   test->setValue(12.345);
   // during the delay we showed the new value
   lines = LiquidCrystal_TC::instance()->getLines();
-  assertEqual("New Mid = 12.345", lines.at(1));
+  assertEqual("Higher = 12.345 ", lines.at(1));
+  assertEqual("PHCalibrationHigher", tc->stateName());
+  tc->loop(false);  // transition to Wait
+  assertEqual("Wait", tc->stateName());
+  delay(2000);
+  assertTrue(tc->isInCalibration());
+  delay(1000);
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationLower
+  tc->loop(false);  // updateState to PHCalibrationLower
+  assertEqual("PHCalibrationLower", tc->stateName());
+  assertTrue(tc->isInCalibration());
+}
+
+unittest(threePointMid) {
+  TankController *tc = TankController::instance();
+  PHProbe *pPHProbe = PHProbe::instance();
+  GODMODE()->reset();
+  pPHProbe->setPh(7.125);
+  float pH = pPHProbe->getPh();
+  assertEqual(7.125, pH);
+
+  std::vector<String> lines;
+  PHCalibrationMid *test = new PHCalibrationMid(tc);
+  tc->setNextState(test, true);
+  assertTrue(tc->isInCalibration());
+  lines = LiquidCrystal_TC::instance()->getLines();
+  assertEqual("              0 ", lines.at(1));
+  pPHProbe->setPh(7.325);
+  lines = LiquidCrystal_TC::instance()->getLines();
+  assertEqual("              0 ", lines.at(1));
+  tc->loop(false);
+  lines = LiquidCrystal_TC::instance()->getLines();
+  assertEqual("              0 ", lines.at(1));
+  // setValue
+  test->setValue(12.345);
+  // during the delay we showed the new value
+  lines = LiquidCrystal_TC::instance()->getLines();
+  assertEqual("Mid = 12.345    ", lines.at(1));
   assertEqual("PHCalibrationMid", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());
-  delay(3000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationLow
-  tc->loop(false);  // updateState to PHCalibrationLow
-  assertEqual("PHCalibrationLow", tc->stateName());
+  delay(2000);
+  assertTrue(tc->isInCalibration());
+  delay(1000);
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationHigh
+  tc->loop(false);  // updateState to PHCalibrationHigh
+  assertEqual("PHCalibrationHigh", tc->stateName());
   assertTrue(tc->isInCalibration());
 }
 

--- a/test/PHCalibrationPromptTest.cpp
+++ b/test/PHCalibrationPromptTest.cpp
@@ -22,9 +22,9 @@ unittest(onePoint) {
   delay(1000);
   assertTrue(tc->isInCalibration());
   delay(1000);
-  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationMid
-  tc->loop(false);  // updateState to PHCalibrationMid
-  assertEqual("PHCalibrationMid", tc->stateName());
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationOnly
+  tc->loop(false);  // updateState to PHCalibrationOnly
+  assertEqual("PHCalibrationOnly", tc->stateName());
 }
 
 unittest(twoPoint) {
@@ -38,6 +38,28 @@ unittest(twoPoint) {
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("1, 2 or 3 point?", lines[0]);
   assertEqual("2-pt pH calib...", lines[1]);
+  assertEqual("PHCalibrationPrompt", tc->stateName());
+  tc->loop(false);  // transition to Wait
+  assertEqual("Wait", tc->stateName());
+  delay(1000);
+  assertTrue(tc->isInCalibration());
+  delay(1000);
+  tc->loop(false);  // after the delay, Wait will call setNextState to prepare to go to PHCalibrationHigher
+  tc->loop(false);  // updateState to PHCalibrationHigher
+  assertEqual("PHCalibrationHigher", tc->stateName());
+}
+
+unittest(threePoint) {
+  TankController* tc = TankController::instance();
+  PHCalibrationPrompt* test = new PHCalibrationPrompt(tc);
+  tc->setNextState(test, true);
+  assertTrue(tc->isInCalibration());
+  // setValue
+  test->setValue(3);
+  // during the delay we showed the new value
+  std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
+  assertEqual("1, 2 or 3 point?", lines[0]);
+  assertEqual("3-pt pH calib...", lines[1]);
   assertEqual("PHCalibrationPrompt", tc->stateName());
   tc->loop(false);  // transition to Wait
   assertEqual("Wait", tc->stateName());

--- a/test/PHControlTest.cpp
+++ b/test/PHControlTest.cpp
@@ -162,7 +162,7 @@ unittest(PhEvenWithTarget) {
  */
 unittest(disableDuringCalibration) {
   assertFalse(tc->isInCalibration());
-  PHCalibrationMid* test = new PHCalibrationMid(tc, 3);
+  PHCalibrationMid* test = new PHCalibrationMid(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // device is initially off and stays off due to calibration

--- a/test/PushingBoxTest.cpp
+++ b/test/PushingBoxTest.cpp
@@ -83,7 +83,7 @@ unittest(SendData) {
 
 unittest(inCalibration) {
   EEPROM_TC::instance()->setTankID(99);
-  PHCalibrationMid *test = new PHCalibrationMid(tc, 3);
+  PHCalibrationMid *test = new PHCalibrationMid(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   EthernetClient::startMockServer(pPushingBox->getServerDomain(), (uint32_t)0, 80);

--- a/test/SDTest.cpp
+++ b/test/SDTest.cpp
@@ -48,7 +48,7 @@ unittest(tankControllerLoop) {
 
 unittest(loopInCalibration) {
   TankController* tc = TankController::instance();
-  PHCalibrationMid* test = new PHCalibrationMid(tc, 3);
+  PHCalibrationMid* test = new PHCalibrationMid(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   char data[250];

--- a/test/SeePHCalibrationTest.cpp
+++ b/test/SeePHCalibrationTest.cpp
@@ -30,4 +30,24 @@ unittest(testOutput) {
   assertEqual("MainMenu", tc->stateName());
 }
 
+unittest(testTimeout) {
+  // Set up
+  TankController* tc = TankController::instance();
+  LiquidCrystal_TC* display = LiquidCrystal_TC::instance();
+  PHProbe* pPHProbe = PHProbe::instance();
+
+  assertEqual("MainMenu", tc->stateName());
+  SeePHCalibration* test = new SeePHCalibration(tc);
+  tc->setNextState(test, true);
+  assertEqual("SeePHCalibration", tc->stateName());
+
+  pPHProbe->setCalibration(2);
+  delay(55000);
+  tc->loop(false);
+  assertEqual("SeePHCalibration", tc->stateName());
+  delay(5000);
+  tc->loop(false);
+  assertEqual("MainMenu", tc->stateName());
+}
+
 unittest_main()

--- a/test/TemperatureControlTest.cpp
+++ b/test/TemperatureControlTest.cpp
@@ -114,7 +114,7 @@ unittest(disableChillerDuringCalibration) {
   control->setTargetTemperature(20);
   control->updateControl(20);
   assertFalse(tc->isInCalibration());
-  PHCalibrationMid* test = new PHCalibrationMid(tc, 3);
+  PHCalibrationMid* test = new PHCalibrationMid(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // chiller is initially off and stays off during calibration
@@ -171,7 +171,7 @@ unittest(disableHeaterDuringCalibration) {
   TemperatureControl::enableHeater(true);
   control = TemperatureControl::instance();
   assertFalse(tc->isInCalibration());
-  PHCalibrationMid* test = new PHCalibrationMid(tc, 3);
+  PHCalibrationMid* test = new PHCalibrationMid(tc);
   tc->setNextState(test, true);
   assertTrue(tc->isInCalibration());
   // heater is initially off, and stays off due to calibration


### PR DESCRIPTION
This renames "pH-midpoint", "pH-lowpoint", and "pH-highpoint" depending on the calibration method:
- 1-point calibration: "Buffer pH"
- 2-point calibration: "Higher buffer pH" and "Lower buffer pH"
- 3-point calibration: "Mid buffer pH", "High buffer pH", and "Low buffer pH" (the last two have been reordered)

After calibration, the confirmation message now times out after 60 seconds.