### PR TITLE
Remote log name

### DIFF
--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v24.10.2-18-g99+';
+const String gitVersion = 'v24.10.2-19-g1d+';

--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v24.10.2-15-gbc+';
+const String gitVersion = 'v24.10.2-17-ge1+';

--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v24.10.2-17-ge1+';
+const String gitVersion = 'v24.10.2-18-g99+';

--- a/extras/scripts/build.sh
+++ b/extras/scripts/build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5654 --skip-unittests 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 ); result=$?
+bundle exec arduino_ci.rb --min-free-space=5650 --skip-unittests 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 ); result=$?
 exit "$result"

--- a/extras/scripts/build.sh
+++ b/extras/scripts/build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5650 --skip-unittests 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 ); result=$?
+bundle exec arduino_ci.rb --min-free-space=5640 --skip-unittests 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 ); result=$?
 exit "$result"

--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -3,6 +3,6 @@
 cp extras/scripts/p*-commit .git/hooks/
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5654 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
+bundle exec arduino_ci.rb --min-free-space=5650 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
 result="${PIPESTATUS[0]}"
 exit "$result"

--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -3,6 +3,6 @@
 cp extras/scripts/p*-commit .git/hooks/
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5650 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
+bundle exec arduino_ci.rb --min-free-space=5640 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
 result="${PIPESTATUS[0]}"
 exit "$result"

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -40,7 +40,8 @@ TankController *TankController::instance(const char *remoteLogName, const char *
   if (!_instance) {
     serial(F("\r\n##############\r\nTankController %s"), TANK_CONTROLLER_VERSION);
     _instance = new TankController();
-    SD_TC::instance()->setRemoteLogName(remoteLogName);
+    SD_TC::instance();
+    RemoteLogPusher::instance()->setRemoteLogName(remoteLogName);
     EEPROM_TC::instance();
     Keypad_TC::instance();
     LiquidCrystal_TC::instance(TANK_CONTROLLER_VERSION);

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v24.10.2-15-gbc+"
+#define VERSION "v24.10.2-17-ge1+"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v24.10.2-18-g99+"
+#define VERSION "v24.10.2-19-g1d+"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v24.10.2-17-ge1+"
+#define VERSION "v24.10.2-18-g99+"

--- a/src/model/RemoteLogPusher.h
+++ b/src/model/RemoteLogPusher.h
@@ -51,13 +51,13 @@ public:
 
   // instance methods
   RemoteLogPusher();
-  const char* getRemoteLogName() {
+  const char *getRemoteLogName() {
     return remoteLogName;
   }
   bool isReadyToPost();
   void loop();
   void pushSoon();
-  void setRemoteLogName(const char* newFileName = nullptr);
+  void setRemoteLogName(const char *newFileName = nullptr);
   bool shouldSendHeadRequest();
 
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)

--- a/src/model/RemoteLogPusher.h
+++ b/src/model/RemoteLogPusher.h
@@ -3,6 +3,8 @@
 
 #include "wrappers/Ethernet_TC.h"
 
+#define MAX_FILE_NAME_LENGTH 28
+
 /*
  * @brief RemoteLogPusher is a singleton that sends data records and remote logs to the server.
  *
@@ -45,12 +47,17 @@ class RemoteLogPusher {
 public:
   // class methods
   static RemoteLogPusher *instance();
+  static void deleteInstance();
 
   // instance methods
   RemoteLogPusher();
+  const char* getRemoteLogName() {
+    return remoteLogName;
+  }
   bool isReadyToPost();
   void loop();
   void pushSoon();
+  void setRemoteLogName(const char* newFileName = nullptr);
   bool shouldSendHeadRequest();
 
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
@@ -84,6 +91,7 @@ private:
   clientState_t state = CLIENT_NOT_CONNECTED;
   uint32_t delayRequestsUntilTime = 40000;  // wait a bit before first request
   const char *serverDomain = "oap.cs.wallawalla.edu";
+  char remoteLogName[MAX_FILE_NAME_LENGTH + 5] = "";  // add ".log" with null-terminator
   char buffer[300];
   unsigned int index = 0;
   bool _isReadyToPost = false;

--- a/src/wrappers/SD_TC.cpp
+++ b/src/wrappers/SD_TC.cpp
@@ -122,8 +122,7 @@ bool SD_TC::format() {
 
 void SD_TC::getRemoteLogContents(char* buffer, int size, uint32_t index) {
   buffer[0] = '\0';
-  const char* logName = PSTR("remote.log");
-  File file = open(logName, O_RDONLY);
+  File file = open(remoteFileName, O_RDONLY);
   if (file) {
     file.seek(index);
     int remaining = file.available();
@@ -276,20 +275,19 @@ void SD_TC::writeToRemoteLog(const char* line) {
   strncpy(mostRecentRemoteLogEntry, line, sizeof(mostRecentRemoteLogEntry));  // Flawfinder: ignore
   mostRecentRemoteLogEntry[sizeof(mostRecentRemoteLogEntry) - 1] = '\0';      // Ensure null-terminated string
 #endif
-  const char* logName = PSTR("remote.log");
-  if (!sd.exists(logName)) {
+  if (!sd.exists(remoteFileName)) {
     // rather than write an entire header line in one buffer, we break it into chunks to save memory
     char buffer[200];
     DataLogger::instance()->writeRemoteFileHeader(buffer, sizeof(buffer), 0);
-    appendStringToPath(buffer, logName, false);
+    appendStringToPath(buffer, remoteFileName, false);
     DataLogger::instance()->writeRemoteFileHeader(buffer, sizeof(buffer), 1);
-    appendStringToPath(buffer, logName, false);
+    appendStringToPath(buffer, remoteFileName, false);
     DataLogger::instance()->writeRemoteFileHeader(buffer, sizeof(buffer), 2);
-    appendStringToPath(buffer, logName, false);
+    appendStringToPath(buffer, remoteFileName, false);
     DataLogger::instance()->writeRemoteFileHeader(buffer, sizeof(buffer), 3);
-    appendStringToPath(buffer, logName);
+    appendStringToPath(buffer, remoteFileName);
   }
-  appendStringToPath(line, logName);
+  appendStringToPath(line, remoteFileName);
   updateRemoteFileSize();
   RemoteLogPusher::instance()->pushSoon();
 }

--- a/src/wrappers/SD_TC.cpp
+++ b/src/wrappers/SD_TC.cpp
@@ -42,7 +42,6 @@ SD_TC::SD_TC() {
   if (!sd.begin(SD_SELECT_PIN)) {
     Serial.println(F("SD_TC failed to initialize!"));
   }
-  remoteLogName[0] = '\0';
 }
 
 /**
@@ -123,10 +122,7 @@ bool SD_TC::format() {
 
 void SD_TC::getRemoteLogContents(char* buffer, int size, uint32_t index) {
   buffer[0] = '\0';
-  const char* logName = getRemoteLogName();
-  if (logName[0] == '\0') {
-    return;
-  }
+  const char* logName = PSTR("remote.log");
   File file = open(logName, O_RDONLY);
   if (file) {
     file.seek(index);
@@ -254,29 +250,14 @@ bool SD_TC::remove(const char* path) {
   return sd.remove(path);
 }
 
-void SD_TC::setRemoteLogName(const char* newFileName) {
-  if (newFileName == nullptr || newFileName[0] == '\0') {
-    remoteLogName[0] = '\0';
-    return;
-  }
-  // See TankController.ino for the definition of remoteLogName
-  if (strnlen(newFileName, MAX_FILE_NAME_LENGTH + 1) <= MAX_FILE_NAME_LENGTH) {
-    // valid file name has been provided (See TankController.ino)
-    snprintf_P(remoteLogName, MAX_FILE_NAME_LENGTH + 5, PSTR("%s.log"), newFileName);
-  }
-}
-
 void SD_TC::todaysDataFileName(char* path, int size) {
   DateTime_TC now = DateTime_TC::now();
   snprintf_P(path, size, (PGM_P)F("%4i%02i%02i.csv"), now.year(), now.month(), now.day());
 }
 
 void SD_TC::updateRemoteFileSize() {
-  if (remoteLogName[0] == '\0') {
-    remoteFileSize = 0;
-    return;
-  }
-  File file = open(remoteLogName, O_RDONLY);
+  const char* logName = PSTR("remote.log");
+  File file = open(logName, O_RDONLY);
   if (file) {
     remoteFileSize = file.size();
     file.close();
@@ -295,23 +276,20 @@ void SD_TC::writeToRemoteLog(const char* line) {
   strncpy(mostRecentRemoteLogEntry, line, sizeof(mostRecentRemoteLogEntry));  // Flawfinder: ignore
   mostRecentRemoteLogEntry[sizeof(mostRecentRemoteLogEntry) - 1] = '\0';      // Ensure null-terminated string
 #endif
-  const char* logName = getRemoteLogName();
-  if (logName[0] == '\0') {
-    return;
-  }
+  const char* logName = PSTR("remote.log");
   if (!sd.exists(logName)) {
     // rather than write an entire header line in one buffer, we break it into chunks to save memory
     char buffer[200];
     DataLogger::instance()->writeRemoteFileHeader(buffer, sizeof(buffer), 0);
-    appendStringToPath(buffer, remoteLogName, false);
+    appendStringToPath(buffer, logName, false);
     DataLogger::instance()->writeRemoteFileHeader(buffer, sizeof(buffer), 1);
-    appendStringToPath(buffer, remoteLogName, false);
+    appendStringToPath(buffer, logName, false);
     DataLogger::instance()->writeRemoteFileHeader(buffer, sizeof(buffer), 2);
-    appendStringToPath(buffer, remoteLogName, false);
+    appendStringToPath(buffer, logName, false);
     DataLogger::instance()->writeRemoteFileHeader(buffer, sizeof(buffer), 3);
-    appendStringToPath(buffer, remoteLogName);
+    appendStringToPath(buffer, logName);
   }
-  appendStringToPath(line, remoteLogName);
+  appendStringToPath(line, logName);
   updateRemoteFileSize();
   RemoteLogPusher::instance()->pushSoon();
 }

--- a/src/wrappers/SD_TC.cpp
+++ b/src/wrappers/SD_TC.cpp
@@ -255,8 +255,7 @@ void SD_TC::todaysDataFileName(char* path, int size) {
 }
 
 void SD_TC::updateRemoteFileSize() {
-  const char* logName = PSTR("remote.log");
-  File file = open(logName, O_RDONLY);
+  File file = open(remoteFileName, O_RDONLY);
   if (file) {
     remoteFileSize = file.size();
     file.close();

--- a/src/wrappers/SD_TC.h
+++ b/src/wrappers/SD_TC.h
@@ -57,6 +57,7 @@ private:
   bool hasHadError = false;
   SdFat sd;
   uint32_t remoteFileSize = 0;
+  const char remoteFileName[12] PROGMEM = "remote.log";
 
   // Max depth of file system search for rootdir()
   // Two is minimum: First for root, second for files

--- a/src/wrappers/SD_TC.h
+++ b/src/wrappers/SD_TC.h
@@ -31,15 +31,11 @@ public:
   uint32_t getRemoteFileSize() {
     return remoteFileSize;
   }
-  const char* getRemoteLogName() {
-    return remoteLogName;
-  }
   bool listRootToBuffer(void (*callWhenFull)(const char*, bool));
   bool mkdir(const char* path);
   File open(const char* path, oflag_t oflag = 0x00);
   void printRootDirectory();
   bool remove(const char* path);
-  void setRemoteLogName(const char* newFileName = nullptr);
   void todaysDataFileName(char* path, int size);
   void writeToRemoteLog(const char* line);
 
@@ -60,7 +56,6 @@ private:
   const uint8_t SD_SELECT_PIN = SS;
   bool hasHadError = false;
   SdFat sd;
-  char remoteLogName[MAX_FILE_NAME_LENGTH + 5] = "";  // add ".log" with null-terminator
   uint32_t remoteFileSize = 0;
 
   // Max depth of file system search for rootdir()

--- a/test/PushingBoxTest.cpp
+++ b/test/PushingBoxTest.cpp
@@ -6,6 +6,7 @@
 #include "EthernetServer_TC.h"
 #include "PHControl.h"
 #include "PushingBox.h"
+#include "RemoteLogPusher.h"
 #include "Serial_TC.h"
 #include "TankController.h"
 #include "ThermalControl.h"
@@ -46,7 +47,7 @@ unittest_teardown() {
 }
 
 unittest(NoTankID) {
-  SD_TC::instance()->setRemoteLogName("90A2DA807B76");
+  RemoteLogPusher::instance()->setRemoteLogName("90A2DA807B76");
   // set tank id to 0, set time interval to 1 minute
   EEPROM_TC::instance()->setTankID(0);
 

--- a/test/RemoteLogPusherTest.cpp
+++ b/test/RemoteLogPusherTest.cpp
@@ -33,7 +33,7 @@ unittest(loopSendsRequests) {
   TankController* tc = TankController::instance();
   RemoteLogPusher* pusher = RemoteLogPusher::instance();
   EthernetClient* pClient = pusher->getClient();
-  SD_TC::instance()->setRemoteLogName("90A2DA807B76");
+  RemoteLogPusher::instance()->setRemoteLogName("90A2DA807B76");
 
   // Set up the server to respond to the HEAD request
   assertTrue(Ethernet_TC::instance(true)->isConnectedToNetwork());

--- a/test/SDTest.cpp
+++ b/test/SDTest.cpp
@@ -190,15 +190,15 @@ unittest(removeFile) {
 
 unittest(writeRemoteLog) {
   SD_TC* sd = SD_TC::instance();
-  sd->setRemoteLogName("Tank1");
+  RemoteLogPusher* pusher = RemoteLogPusher::instance();
+  pusher->setRemoteLogName("Tank1");
   delay(60000);  // remote logs don't get written immediately
   char data[20];
-  sd->setRemoteLogName("90A2DA807B76");
-  RemoteLogPusher* pusher = RemoteLogPusher::instance();
+  pusher->setRemoteLogName("90A2DA807B76");
 
-  assertEqual("90A2DA807B76.log", sd->getRemoteLogName());
+  assertEqual("90A2DA807B76.log", pusher->getRemoteLogName());
   sd->updateRemoteLogFileSizeForTest();
-  assertFalse(sd->exists("90A2DA807B76.log"));
+  assertFalse(sd->exists("remote.log"));
   assertEqual(0, sd->getRemoteFileSize());
   pusher->setShouldSentHeadRequest(false);
   assertFalse(pusher->shouldSendHeadRequest());
@@ -207,14 +207,14 @@ unittest(writeRemoteLog) {
   sd->writeToRemoteLog("line 1");  // also writes header row
   sd->updateRemoteLogFileSizeForTest();
   assertTrue(pusher->basicShouldSendHeadRequest());
-  assertTrue(sd->exists("90A2DA807B76.log"));
+  assertTrue(sd->exists("remote.log"));
   int size = sd->getRemoteFileSize();
   sd->writeToRemoteLog("line 2");
   sd->updateRemoteLogFileSizeForTest();
   assertEqual(size + strlen("line 2\n"), sd->getRemoteFileSize());  // Flawfinder: ignore
 
   // verify contents of remote log
-  File file = sd->open("90A2DA807B76.log");
+  File file = sd->open("remote.log");
   file.seek(size);
   file.read(data, 7);  // Flawfinder: ignore
   file.close();
@@ -226,7 +226,7 @@ unittest(getRemoteLogContents) {
   SD_TC* sd = SD_TC::instance();
 
   // write data
-  sd->setRemoteLogName("Tank1");
+  // sd->setRemoteLogName("Tank1");
   sd->writeToRemoteLog("line 1");
   sd->updateRemoteLogFileSizeForTest();
   int size = sd->getRemoteFileSize();
@@ -239,42 +239,42 @@ unittest(getRemoteLogContents) {
 }
 
 unittest(noRemoteLogFileName) {
-  SD_TC* sd = SD_TC::instance();
-  sd->setRemoteLogName("Tank1");
-  sd->setRemoteLogName("");
-  assertEqual("", sd->getRemoteLogName());
+  RemoteLogPusher* pusher = RemoteLogPusher::instance();
+  pusher->setRemoteLogName("Tank1");
+  pusher->setRemoteLogName("");
+  assertEqual("", pusher->getRemoteLogName());
 }
 
 unittest(validRemoteLogFileName) {
-  SD_TC* sd = SD_TC::instance();
-  sd->setRemoteLogName("Tank1");
-  assertEqual("Tank1.log", sd->getRemoteLogName());
+  RemoteLogPusher* pusher = RemoteLogPusher::instance();
+  pusher->setRemoteLogName("Tank1");
+  assertEqual("Tank1.log", pusher->getRemoteLogName());
 }
 
 unittest(longRemoteLogFileName) {
-  SD_TC* sd = SD_TC::instance();
-  sd->setRemoteLogName("1234567890123456789012345678");  // maximum length
-  assertEqual("1234567890123456789012345678.log", sd->getRemoteLogName());
-  sd->setRemoteLogName("12345678901234567890123456789");  // one character too many
-  assertEqual("1234567890123456789012345678.log", sd->getRemoteLogName());
+  RemoteLogPusher* pusher = RemoteLogPusher::instance();
+  pusher->setRemoteLogName("1234567890123456789012345678");  // maximum length
+  assertEqual("1234567890123456789012345678.log", pusher->getRemoteLogName());
+  pusher->setRemoteLogName("12345678901234567890123456789");  // one character too many
+  assertEqual("1234567890123456789012345678.log", pusher->getRemoteLogName());
 }
 
 unittest(remoteLogName) {
   TankController::deleteInstance();
   TankController* tc = TankController::instance("remoteLog");
-  SD_TC* sd = SD_TC::instance();
-  const char* name = sd->getRemoteLogName();
+  RemoteLogPusher* pusher = RemoteLogPusher::instance();
+  const char* name = pusher->getRemoteLogName();
   assertEqual("remoteLog.log", name);
 
   TankController::deleteInstance();
   SD_TC::deleteInstance();
+  RemoteLogPusher::deleteInstance();
   tc = TankController::instance();
-  sd = SD_TC::instance();
-  name = sd->getRemoteLogName();
+  name = pusher->getRemoteLogName();
   assertEqual("", name);
 
-  sd->setRemoteLogName("newName");
-  name = sd->getRemoteLogName();
+  pusher->setRemoteLogName("newName");
+  name = pusher->getRemoteLogName();
   assertEqual("newName.log", name);
 }
 


### PR DESCRIPTION
The SD card seems to support only 8.3 names so we should not use the provided filename on local storage. Instead of storing it with the SD wrapper, we now store it with the RemoteLogPusher class.