### PR TITLE
Reset EEPROM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ all : \
 	$(BIN)/PIDTest.cpp.bin \
 	$(BIN)/PushingBoxTest.cpp.bin \
 	$(BIN)/RemoteLogPusherTest.cpp.bin \
+	$(BIN)/ResetEEPROMTest.cpp.bin \
 	$(BIN)/ResetPHCalibrationTest.cpp.bin \
 	$(BIN)/ResetThermalCalibrationTest.cpp.bin \
 	$(BIN)/SDTest.cpp.bin \
@@ -175,6 +176,15 @@ $(BIN)/PushingBoxTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/PushingBoxTest.cpp $
 $(BIN)/RemoteLogPusherTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/RemoteLogPusherTest.cpp $(HEADERS)
 	$(GPP_TEST) -o $(BIN)/RemoteLogPusherTest.cpp.bin $(TEST)/RemoteLogPusherTest.cpp -larduino
 
+$(BIN)/ResetEEPROMTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/ResetEEPROMTest.cpp $(HEADERS)
+	$(GPP_TEST) -o $(BIN)/ResetEEPROMTest.cpp.bin $(TEST)/ResetEEPROMTest.cpp -larduino
+
+$(BIN)/ResetPHCalibrationTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/ResetPHCalibrationTest.cpp $(HEADERS)
+	$(GPP_TEST) -o $(BIN)/ResetPHCalibrationTest.cpp.bin $(TEST)/ResetPHCalibrationTest.cpp -larduino
+
+$(BIN)/ResetThermalCalibrationTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/ResetThermalCalibrationTest.cpp $(HEADERS)
+	$(GPP_TEST) -o $(BIN)/ResetThermalCalibrationTest.cpp.bin $(TEST)/ResetThermalCalibrationTest.cpp -larduino
+
 $(BIN)/SDTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SDTest.cpp $(HEADERS)
 	$(GPP_TEST) -o $(BIN)/SDTest.cpp.bin $(TEST)/SDTest.cpp -larduino
 
@@ -229,9 +239,6 @@ $(BIN)/SetKITest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SetKITest.cpp $(HEADERS)
 $(BIN)/SetKPTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SetKPTest.cpp $(HEADERS)
 	$(GPP_TEST) -o $(BIN)/SetKPTest.cpp.bin $(TEST)/SetKPTest.cpp -larduino
 
-$(BIN)/ResetPHCalibrationTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/ResetPHCalibrationTest.cpp $(HEADERS)
-	$(GPP_TEST) -o $(BIN)/ResetPHCalibrationTest.cpp.bin $(TEST)/ResetPHCalibrationTest.cpp -larduino
-
 $(BIN)/SetPHTargetTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SetPHTargetTest.cpp $(HEADERS)
 	$(GPP_TEST) -o $(BIN)/SetPHTargetTest.cpp.bin $(TEST)/SetPHTargetTest.cpp -larduino
 
@@ -240,9 +247,6 @@ $(BIN)/SetPHSineWaveTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SetPHSineWaveTest
 
 $(BIN)/SetTankIDTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SetTankIDTest.cpp $(HEADERS)
 	$(GPP_TEST) -o $(BIN)/SetTankIDTest.cpp.bin $(TEST)/SetTankIDTest.cpp -larduino
-
-$(BIN)/ResetThermalCalibrationTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/ResetThermalCalibrationTest.cpp $(HEADERS)
-	$(GPP_TEST) -o $(BIN)/ResetThermalCalibrationTest.cpp.bin $(TEST)/ResetThermalCalibrationTest.cpp -larduino
 
 $(BIN)/SetThermalTargetTest.cpp.bin: $(BIN)/libarduino.so $(TEST)/SetThermalTargetTest.cpp $(HEADERS)
 	$(GPP_TEST) -o $(BIN)/SetThermalTargetTest.cpp.bin $(TEST)/SetThermalTargetTest.cpp -larduino

--- a/Makefile
+++ b/Makefile
@@ -377,6 +377,7 @@ OBJECTS=$(BIN)/Arduino.o \
 	$(BIN)/PHCalibrationMid.o \
 	$(BIN)/PHCalibrationPrompt.o \
 	$(BIN)/RemoteLogPusher.o \
+	$(BIN)/ResetEEPROM.o \
 	$(BIN)/SeeDeviceAddress.o \
 	$(BIN)/SeeDeviceUptime.o \
 	$(BIN)/SeeFreeMemory.o \
@@ -505,6 +506,9 @@ $(BIN)/PHCalibrationPrompt.o: $(SRC)/UIState/PHCalibrationPrompt.cpp $(HEADERS)
 
 $(BIN)/RemoteLogPusher.o: $(SRC)/model/RemoteLogPusher.cpp $(HEADERS)
 	g++ -c $(FLAGS) $(INCLUDE) -o $(BIN)/RemoteLogPusher.o $(SRC)/model/RemoteLogPusher.cpp
+
+$(BIN)/ResetEEPROM.o: $(SRC)/UIState/ResetEEPROM.cpp $(HEADERS)
+	g++ -c $(FLAGS) $(INCLUDE) -o $(BIN)/ResetEEPROM.o $(SRC)/UIState/ResetEEPROM.cpp
 
 $(BIN)/SeeDeviceAddress.o: $(SRC)/UIState/SeeDeviceAddress.cpp $(HEADERS)
 	g++ -c $(FLAGS) $(INCLUDE) -o $(BIN)/SeeDeviceAddress.o $(SRC)/UIState/SeeDeviceAddress.cpp

--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v25.4.1        +';
+const String gitVersion = 'v25.4.1-8-g7e17+';

--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v25.4.1-12-g2e8+';
+const String gitVersion = 'v25.4.1-13-gb8f+';

--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v25.4.1-8-g7e17+';
+const String gitVersion = 'v25.4.1-9-g52f1+';

--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v25.4.1-14-g6a5+';
+const String gitVersion = 'v25.4.1-17-g80b+';

--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v25.4.1-9-g52f1+';
+const String gitVersion = 'v25.4.1-10-gd09+';

--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v25.4.1-10-gd09+';
+const String gitVersion = 'v25.4.1-11-gabe+';

--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v25.4.1-11-gabe+';
+const String gitVersion = 'v25.4.1-12-g2e8+';

--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v25.4.1-13-gb8f+';
+const String gitVersion = 'v25.4.1-14-g6a5+';

--- a/extras/device_client/lib/model/version.dart
+++ b/extras/device_client/lib/model/version.dart
@@ -1,1 +1,1 @@
-const String gitVersion = 'v25.4.1-17-g80b+';
+const String gitVersion = 'v25.4.1-18-g9ac+';

--- a/extras/scripts/build.sh
+++ b/extras/scripts/build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5640 --skip-unittests 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 ); result=$?
+bundle exec arduino_ci.rb --min-free-space=5632 --skip-unittests 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 ); result=$?
 exit "$result"

--- a/extras/scripts/testAndBuild.sh
+++ b/extras/scripts/testAndBuild.sh
@@ -3,6 +3,6 @@
 cp extras/scripts/p*-commit .git/hooks/
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec arduino_ci.rb --min-free-space=5640 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
+bundle exec arduino_ci.rb --min-free-space=5632 1> >(tee stdout.txt ) 2> >(tee stderr.txt >&2 )
 result="${PIPESTATUS[0]}"
 exit "$result"

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -45,15 +45,15 @@ TankController* TankController::instance(const char* remoteLogName, const char* 
     RemoteLogPusher::instance()->setRemoteLogName(remoteLogName);
     EEPROM_TC::instance();
     Keypad_TC::instance();
-    bool resetEEPROM = Keypad_TC::instance()->getKey() == 'C';
-    if (resetEEPROM) {
+    char key = Keypad_TC::instance()->getKey();
+    if (key == '1') {
       EEPROM_TC::instance()->setEEPROMAccessEnabled(false);
       serial(F("EEPROM access disabled"));
     };
     LiquidCrystal_TC::instance(TANK_CONTROLLER_VERSION);
     DataLogger::instance();
     DateTime_TC::rtc();
-    Ethernet_TC::instance();
+    Ethernet_TC::instance(key == NO_KEY ? 60000 : 1);
     EthernetServer_TC::instance();
     ThermalProbe_TC::instance();
     ThermalControl::instance();
@@ -61,9 +61,8 @@ TankController* TankController::instance(const char* remoteLogName, const char* 
     PHControl::instance();
     PID_TC::instance();
     pinMode(LED_BUILTIN, OUTPUT);
-    // _instance->state = resetEEPROM ? (UIState*)new ResetEEPROM() : (UIState*)new MainMenu();
     _instance->state = new MainMenu();
-    if (resetEEPROM) {
+    if (key == '1') {
       _instance->setNextState(new ResetEEPROM());
     }
     PushingBox::instance(pushingBoxID);

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 #include "UIState/MainMenu.h"
+#include "UIState/ResetEEPROM.h"
 #include "UIState/UIState.h"
 #include "Version.h"
 #include "model/DataLogger.h"
@@ -31,18 +32,23 @@ const char TANK_CONTROLLER_VERSION[] = VERSION;
 /**
  * static variable to hold singleton
  */
-TankController *TankController::_instance = nullptr;
+TankController* TankController::_instance = nullptr;
 
 /**
  * static function to return singleton
  */
-TankController *TankController::instance(const char *remoteLogName, const char *pushingBoxID, int tzOffsetHrs) {
+TankController* TankController::instance(const char* remoteLogName, const char* pushingBoxID, int tzOffsetHrs) {
   if (!_instance) {
     serial(F("\r\n##############\r\nTankController %s"), TANK_CONTROLLER_VERSION);
     _instance = new TankController();
     SD_TC::instance();
     RemoteLogPusher::instance()->setRemoteLogName(remoteLogName);
     EEPROM_TC::instance();
+    bool resetEEPROM = Keypad_TC::instance()->getKey() == 'C';
+    if (resetEEPROM) {
+      EEPROM_TC::instance()->setEEPROMAccessEnabled(false);
+      serial(F("EEPROM access disabled"));
+    };
     Keypad_TC::instance();
     LiquidCrystal_TC::instance(TANK_CONTROLLER_VERSION);
     DataLogger::instance();
@@ -55,7 +61,7 @@ TankController *TankController::instance(const char *remoteLogName, const char *
     PHControl::instance();
     PID_TC::instance();
     pinMode(LED_BUILTIN, OUTPUT);
-    _instance->state = new MainMenu();
+    _instance->state = resetEEPROM ? (UIState*)new ResetEEPROM() : (UIState*)new MainMenu();
     PushingBox::instance(pushingBoxID);
     GetTime::instance(tzOffsetHrs);
     serial(F("Free memory = %i"), _instance->freeMemory());
@@ -114,7 +120,7 @@ int TankController::freeMemory() {
 #if defined(ARDUINO_CI_COMPILATION_MOCKS)
   return 1024;
 #else
-  extern char *__brkval;
+  extern char* __brkval;
   int topOfStack;
 
   return (int)((size_t)&topOfStack) - ((size_t)__brkval);
@@ -146,7 +152,7 @@ void TankController::handleUI() {
       // we already have a next state teed-up, do don't try to return to main menu
     } else if (millis() - lastKeypadTime > IDLE_TIMEOUT) {
       // time since last keypress exceeds the idle timeout, so return to main menu
-      setNextState((UIState *)new MainMenu());
+      setNextState((UIState*)new MainMenu());
       lastKeypadTime = 0;  // so we don't do this until another keypress!
     }
   } else {
@@ -211,7 +217,7 @@ void TankController::serialEvent1() {
 /**
  * Set the next state
  */
-void TankController::setNextState(UIState *newState, bool update) {
+void TankController::setNextState(UIState* newState, bool update) {
   assert(nextState == nullptr);
   nextState = newState;
   if (update) {
@@ -231,7 +237,7 @@ void TankController::setup() {
  * Public member function used to get the current state name.
  * This is primarily used by testing.
  */
-const __FlashStringHelper *TankController::stateName() {
+const __FlashStringHelper* TankController::stateName() {
   return state->name();
 }
 
@@ -262,13 +268,13 @@ void TankController::updateState() {
 /**
  * What is the current version?
  */
-const char *TankController::version() {
+const char* TankController::version() {
   return TANK_CONTROLLER_VERSION;
 }
 
 #if defined(__CYGWIN__)
-size_t strnlen(const char *s, size_t n) {
-  void *found = memchr(s, '\0', n);
-  return found ? (size_t)((char *)found - s) : n;
+size_t strnlen(const char* s, size_t n) {
+  void* found = memchr(s, '\0', n);
+  return found ? (size_t)((char*)found - s) : n;
 }
 #endif

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -44,12 +44,12 @@ TankController* TankController::instance(const char* remoteLogName, const char* 
     SD_TC::instance();
     RemoteLogPusher::instance()->setRemoteLogName(remoteLogName);
     EEPROM_TC::instance();
+    Keypad_TC::instance();
     bool resetEEPROM = Keypad_TC::instance()->getKey() == 'C';
     if (resetEEPROM) {
       EEPROM_TC::instance()->setEEPROMAccessEnabled(false);
       serial(F("EEPROM access disabled"));
     };
-    Keypad_TC::instance();
     LiquidCrystal_TC::instance(TANK_CONTROLLER_VERSION);
     DataLogger::instance();
     DateTime_TC::rtc();
@@ -61,7 +61,11 @@ TankController* TankController::instance(const char* remoteLogName, const char* 
     PHControl::instance();
     PID_TC::instance();
     pinMode(LED_BUILTIN, OUTPUT);
-    _instance->state = resetEEPROM ? (UIState*)new ResetEEPROM() : (UIState*)new MainMenu();
+    // _instance->state = resetEEPROM ? (UIState*)new ResetEEPROM() : (UIState*)new MainMenu();
+    _instance->state = new MainMenu();
+    if (resetEEPROM) {
+      _instance->setNextState(new ResetEEPROM());
+    }
     PushingBox::instance(pushingBoxID);
     GetTime::instance(tzOffsetHrs);
     serial(F("Free memory = %i"), _instance->freeMemory());

--- a/src/TankController.cpp
+++ b/src/TankController.cpp
@@ -28,6 +28,26 @@
 
 const char TANK_CONTROLLER_VERSION[] = VERSION;
 
+// ------------ Early Boot Watchdog Disable ------------
+/**
+ * Disable the watchdog timer immediately on boot, before main()/setup() runs.
+ *
+ * After a watchdog reset on AVR, the WDT remains enabled with whatever timeout
+ * triggered the reset (e.g. the 15 ms used by ResetEEPROM). The stock Mega2560
+ * bootloader does not clear MCUSR or call wdt_disable(), and it takes longer
+ * than 15 ms to hand control to the sketch -- so the WDT fires again inside
+ * the bootloader, looping forever and appearing as a "freeze." Clearing MCUSR
+ * and disabling the WDT from .init3 runs before the C runtime / main() and
+ * breaks that loop. See avr-libc <avr/wdt.h> documentation.
+ */
+#if !defined(ARDUINO_CI_COMPILATION_MOCKS)
+void disableWatchdogAtBoot(void) __attribute__((naked, used, section(".init3")));
+void disableWatchdogAtBoot(void) {
+  MCUSR = 0;
+  wdt_disable();
+}
+#endif
+
 // ------------ Class Methods ------------
 /**
  * static variable to hold singleton
@@ -53,7 +73,7 @@ TankController* TankController::instance(const char* remoteLogName, const char* 
     LiquidCrystal_TC::instance(TANK_CONTROLLER_VERSION);
     DataLogger::instance();
     DateTime_TC::rtc();
-    Ethernet_TC::instance(key == NO_KEY ? 60000 : 1);
+    Ethernet_TC::instance(key == NO_KEY ? (long)60000 : (long)1);  // if a key is held, use a short timeout
     EthernetServer_TC::instance();
     ThermalProbe_TC::instance();
     ThermalControl::instance();

--- a/src/UIState/ResetEEPROM.cpp
+++ b/src/UIState/ResetEEPROM.cpp
@@ -26,3 +26,8 @@ void ResetEEPROM::handleKey(char key) {
       break;
   };
 }
+
+void ResetEEPROM::start() {
+  LiquidCrystal_TC::instance()->writeLine(prompt(), 0);
+  LiquidCrystal_TC::instance()->writeLine(F("D: Cancel"), 1);
+}

--- a/src/UIState/ResetEEPROM.cpp
+++ b/src/UIState/ResetEEPROM.cpp
@@ -10,11 +10,13 @@
 void ResetEEPROM::handleKey(char key) {
   switch (key) {
     case 'A':  // Save (erase EEPROM)
-      EEPROM_TC::instance()->resetAll();
+      EEPROM_TC::instance()->resetEEPROM();
       returnToMainMenu();
       break;
     case 'D':  // Don't save (cancel)
-      returnToMainMenu();
+      wdt_enable(WDTO_15MS);
+      do {
+      } while (true);
       break;
     default:
       break;

--- a/src/UIState/ResetEEPROM.cpp
+++ b/src/UIState/ResetEEPROM.cpp
@@ -1,0 +1,22 @@
+/**
+ * ResetEEPROM.cpp
+ */
+#include "ResetEEPROM.h"
+
+#include "Wait.h"
+#include "wrappers/EEPROM_TC.h"
+#include "wrappers/LiquidCrystal_TC.h"
+
+void ResetEEPROM::handleKey(char key) {
+  switch (key) {
+    case 'A':  // Save (erase EEPROM)
+      EEPROM_TC::instance()->resetAll();
+      returnToMainMenu();
+      break;
+    case 'D':  // Don't save (cancel)
+      returnToMainMenu();
+      break;
+    default:
+      break;
+  };
+}

--- a/src/UIState/ResetEEPROM.cpp
+++ b/src/UIState/ResetEEPROM.cpp
@@ -3,6 +3,8 @@
  */
 #include "ResetEEPROM.h"
 
+#include <avr/wdt.h>
+
 #include "Wait.h"
 #include "wrappers/EEPROM_TC.h"
 #include "wrappers/LiquidCrystal_TC.h"
@@ -11,7 +13,9 @@ void ResetEEPROM::handleKey(char key) {
   switch (key) {
     case 'A':  // Save (erase EEPROM)
       EEPROM_TC::instance()->resetEEPROM();
-      returnToMainMenu();
+      wdt_enable(WDTO_15MS);
+      do {
+      } while (true);
       break;
     case 'D':  // Don't save (cancel)
       wdt_enable(WDTO_15MS);

--- a/src/UIState/ResetEEPROM.h
+++ b/src/UIState/ResetEEPROM.h
@@ -1,0 +1,18 @@
+/**
+ * ResetEEPROM.h
+ *
+ * Clear EEPROM
+ */
+#pragma once
+#include "UIState.h"
+
+class ResetEEPROM : public UIState {
+public:
+  void handleKey(char key);
+  const __FlashStringHelper* name() {
+    return F("ResetEEPROM");
+  }
+  const __FlashStringHelper* prompt() {
+    return F("A: Erase EEPROM");
+  };
+};

--- a/src/UIState/ResetEEPROM.h
+++ b/src/UIState/ResetEEPROM.h
@@ -1,7 +1,8 @@
 /**
  * ResetEEPROM.h
  *
- * Clear EEPROM
+ * Asks whether to reset EEPROM to factory default, which is useful if the data is corrupted and causing crashes. This
+ * is accessed by holding the 'C' key on the keypad during startup. The device is rebooted after the selection is made.
  */
 #pragma once
 #include "UIState.h"
@@ -13,9 +14,9 @@ public:
     return true;
   }
   const __FlashStringHelper* name() {
-    return F("ResetEEPROM");
+    return F("Erase EEPROM?");
   }
   const __FlashStringHelper* prompt() {
-    return F("A: Erase EEPROM");
+    return F("A: Erase  D: Cancel");
   };
 };

--- a/src/UIState/ResetEEPROM.h
+++ b/src/UIState/ResetEEPROM.h
@@ -14,9 +14,9 @@ public:
     return true;
   }
   const __FlashStringHelper* name() {
-    return F("Erase EEPROM?");
+    return F("ResetEEPROM");
   }
   const __FlashStringHelper* prompt() {
-    return F("A: Erase  D: Cancel");
+    return F("A: Erase EEPROM");
   };
 };

--- a/src/UIState/ResetEEPROM.h
+++ b/src/UIState/ResetEEPROM.h
@@ -2,7 +2,7 @@
  * ResetEEPROM.h
  *
  * Asks whether to reset EEPROM to factory default, which is useful if the data is corrupted and causing crashes. This
- * is accessed by holding the 'C' key on the keypad during startup. The device is rebooted after the selection is made.
+ * is accessed by holding the '1' key on the keypad during startup. The device is rebooted after the selection is made.
  */
 #pragma once
 #include "UIState.h"

--- a/src/UIState/ResetEEPROM.h
+++ b/src/UIState/ResetEEPROM.h
@@ -9,6 +9,9 @@
 class ResetEEPROM : public UIState {
 public:
   void handleKey(char key);
+  bool isInCalibration() {
+    return true;
+  }
   const __FlashStringHelper* name() {
     return F("ResetEEPROM");
   }

--- a/src/UIState/ResetEEPROM.h
+++ b/src/UIState/ResetEEPROM.h
@@ -9,15 +9,15 @@
 
 class ResetEEPROM : public UIState {
 public:
-  void handleKey(char key);
-  bool isInCalibration() {
+  void handleKey(char key) override;
+  bool isInCalibration() override {
     return true;
   }
   void start() override;
-  const __FlashStringHelper* name() {
+  const __FlashStringHelper* name() override {
     return F("ResetEEPROM");
   }
-  const __FlashStringHelper* prompt() {
+  const __FlashStringHelper* prompt() override {
     return F("A: Erase EEPROM");
   };
 };

--- a/src/UIState/ResetEEPROM.h
+++ b/src/UIState/ResetEEPROM.h
@@ -13,6 +13,7 @@ public:
   bool isInCalibration() {
     return true;
   }
+  void start() override;
   const __FlashStringHelper* name() {
     return F("ResetEEPROM");
   }

--- a/src/UIState/ResetPHCalibration.cpp
+++ b/src/UIState/ResetPHCalibration.cpp
@@ -1,5 +1,5 @@
 /**
- * SetCalibrationClear.cpp
+ * ResetPHCalibration.cpp
  */
 #include "ResetPHCalibration.h"
 

--- a/src/UIState/ResetThermalCalibration.cpp
+++ b/src/UIState/ResetThermalCalibration.cpp
@@ -1,5 +1,5 @@
 /**
- * SetCalibrationClear.cpp
+ * ResetThermalCalibration.cpp
  */
 #include "ResetThermalCalibration.h"
 

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v25.4.1-13-gb8f+"
+#define VERSION "v25.4.1-14-g6a5+"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v25.4.1-14-g6a5+"
+#define VERSION "v25.4.1-17-g80b+"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v25.4.1-17-g80b+"
+#define VERSION "v25.4.1-18-g9ac+"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v25.4.1        +"
+#define VERSION "v25.4.1-8-g7e17+"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v25.4.1-10-gd09+"
+#define VERSION "v25.4.1-11-gabe+"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v25.4.1-9-g52f1+"
+#define VERSION "v25.4.1-10-gd09+"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v25.4.1-8-g7e17+"
+#define VERSION "v25.4.1-9-g52f1+"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v25.4.1-11-gabe+"
+#define VERSION "v25.4.1-12-g2e8+"

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,1 +1,1 @@
-#define VERSION "v25.4.1-12-g2e8+"
+#define VERSION "v25.4.1-13-gb8f+"

--- a/src/wrappers/EEPROM_TC.cpp
+++ b/src/wrappers/EEPROM_TC.cpp
@@ -27,7 +27,8 @@ float EEPROM_TC::eepromReadFloat(uint16_t address) {
   float value = 0.0;
   byte* p = (byte*)(void*)&value;
   for (size_t i = 0; i < sizeof(value); i++) {
-    *p++ = EEPROM.read(address++);
+    *p++ = eepromAccessEnabled ? EEPROM.read(address++)
+                               : 1;  // if access is disabled, return 1s which is the default value for erased EEPROM
   }
   return value;
 }
@@ -39,6 +40,10 @@ float EEPROM_TC::eepromReadFloat(uint16_t address) {
  * @param value
  */
 void EEPROM_TC::eepromWriteFloat(uint16_t address, float value) {
+  if (!eepromAccessEnabled) {
+    serial(F("EEPROM disabled, cannot write to address %i"), address);
+    return;
+  }
   if (eepromReadFloat(address) != value) {
     byte* p = (byte*)(void*)&value;
     for (size_t i = 0; i < sizeof(value); i++) {
@@ -52,7 +57,8 @@ int32_t EEPROM_TC::eepromReadInt(uint16_t address) {
   int32_t value = 0;
   byte* p = (byte*)(void*)&value;
   for (size_t i = 0; i < sizeof(value); i++) {
-    *p++ = EEPROM.read(address++);
+    *p++ = eepromAccessEnabled ? EEPROM.read(address++)
+                               : 1;  // if access is disabled, return 1s which is the default value for erased EEPROM
   }
   return value;
 }
@@ -64,6 +70,10 @@ int32_t EEPROM_TC::eepromReadInt(uint16_t address) {
  * @param value
  */
 void EEPROM_TC::eepromWriteInt(uint16_t address, int32_t value) {
+  if (!eepromAccessEnabled) {
+    serial(F("EEPROM disabled, cannot write to address %i"), address);
+    return;
+  }
   if (eepromReadInt(address) != value) {
     byte* p = (byte*)(void*)&value;
     for (size_t i = 0; i < sizeof(value); i++) {
@@ -77,7 +87,7 @@ void EEPROM_TC::eepromWriteInt(uint16_t address, int32_t value) {
  * @brief resets EEPROM to factory default by writing 1 to all addresses, and triggers a remote log in DataLogger
  *
  */
-void EEPROM_TC::resetAll() {
+void EEPROM_TC::resetEEPROM() {
   for (uint16_t i = 0; i < EEPROM.length(); i++) {
     EEPROM.update(i, 1);
   }

--- a/src/wrappers/EEPROM_TC.cpp
+++ b/src/wrappers/EEPROM_TC.cpp
@@ -73,6 +73,17 @@ void EEPROM_TC::eepromWriteInt(uint16_t address, int32_t value) {
   }
 }
 
+/**
+ * @brief resets EEPROM to factory default by writing 1 to all addresses, and triggers a remote log in DataLogger
+ *
+ */
+void EEPROM_TC::resetAll() {
+  for (uint16_t i = 0; i < EEPROM.length(); i++) {
+    EEPROM.update(i, 1);
+  }
+  DataLogger::instance()->writeWarningSoon();  // log all settings
+}
+
 // getter methods
 float EEPROM_TC::getAmplitude() {
   return eepromReadFloat(AMPLITUDE_ADDRESS);

--- a/src/wrappers/EEPROM_TC.cpp
+++ b/src/wrappers/EEPROM_TC.cpp
@@ -84,14 +84,14 @@ void EEPROM_TC::eepromWriteInt(uint16_t address, int32_t value) {
 }
 
 /**
- * @brief resets EEPROM to factory default by writing 1 to all addresses, and triggers a remote log in DataLogger
+ * @brief resets EEPROM to factory default by writing 1 to all addresses, and reenables read/write functions
  *
  */
 void EEPROM_TC::resetEEPROM() {
   for (uint16_t i = 0; i < EEPROM.length(); i++) {
     EEPROM.update(i, 1);
   }
-  DataLogger::instance()->writeWarningSoon();  // log all settings
+  eepromAccessEnabled = true;
 }
 
 // getter methods

--- a/src/wrappers/EEPROM_TC.cpp
+++ b/src/wrappers/EEPROM_TC.cpp
@@ -28,7 +28,7 @@ float EEPROM_TC::eepromReadFloat(uint16_t address) {
   byte* p = (byte*)(void*)&value;
   for (size_t i = 0; i < sizeof(value); i++) {
     *p++ = eepromAccessEnabled ? EEPROM.read(address++)
-                               : 1;  // if access is disabled, return 1s which is the default value for erased EEPROM
+                               : 0xff;  // if access is disabled, return 1s which is the default value for erased EEPROM
   }
   return value;
 }
@@ -58,7 +58,7 @@ int32_t EEPROM_TC::eepromReadInt(uint16_t address) {
   byte* p = (byte*)(void*)&value;
   for (size_t i = 0; i < sizeof(value); i++) {
     *p++ = eepromAccessEnabled ? EEPROM.read(address++)
-                               : 1;  // if access is disabled, return 1s which is the default value for erased EEPROM
+                               : 0xff;  // if access is disabled, return 1s which is the default value for erased EEPROM
   }
   return value;
 }
@@ -84,12 +84,12 @@ void EEPROM_TC::eepromWriteInt(uint16_t address, int32_t value) {
 }
 
 /**
- * @brief resets EEPROM to factory default by writing 1 to all addresses, and reenables read/write functions
+ * @brief resets EEPROM to factory default by writing 1 to all bits, and reenables read/write functions
  *
  */
 void EEPROM_TC::resetEEPROM() {
   for (uint16_t i = 0; i < EEPROM.length(); i++) {
-    EEPROM.update(i, 1);
+    EEPROM.update(i, 0xff);
   }
   eepromAccessEnabled = true;
 }

--- a/src/wrappers/EEPROM_TC.h
+++ b/src/wrappers/EEPROM_TC.h
@@ -11,6 +11,7 @@ public:
   int32_t eepromReadInt(uint16_t address);
   void eepromWriteFloat(uint16_t address, float value);
   void eepromWriteInt(uint16_t address, int32_t value);
+  void resetAll();
 
   // accessor methods
   float getAmplitude();                  // not used

--- a/src/wrappers/EEPROM_TC.h
+++ b/src/wrappers/EEPROM_TC.h
@@ -11,7 +11,7 @@ public:
   int32_t eepromReadInt(uint16_t address);
   void eepromWriteFloat(uint16_t address, float value);
   void eepromWriteInt(uint16_t address, int32_t value);
-  void resetAll();
+  void resetEEPROM();
 
   // accessor methods
   float getAmplitude();                  // not used
@@ -54,6 +54,9 @@ public:
   float getTempSeriesSize();     // not used
 
   // setter methods
+  void setEEPROMAccessEnabled(bool enabled) {
+    eepromAccessEnabled = enabled;
+  }
   void setAmplitude(float value);
   void setThermalCorrection(float value);
   void setFrequency(float value);
@@ -98,6 +101,8 @@ public:
   void writeAllToString(char* destination, int size);
 
 private:
+  bool eepromAccessEnabled = true;  // disables read/write functions if false to prevent infinite loop when EEPROM is
+                                    // corrupted and causing crashes
   // note that while Arduino floats are 4 bytes, we sometimes allow 8 bytes!
   // instance variables from v0.197
   const uint16_t PH_ADDRESS = 0;                   // 9.999

--- a/src/wrappers/Ethernet_TC.cpp
+++ b/src/wrappers/Ethernet_TC.cpp
@@ -9,14 +9,12 @@
 Ethernet_TC *Ethernet_TC::_instance = nullptr;
 
 // Establishes the Ethernet connection and sets class variables
-Ethernet_TC::Ethernet_TC() {
+Ethernet_TC::Ethernet_TC(long timeout) {
   pinMode(SD_SELECT_PIN, OUTPUT);
   digitalWrite(SD_SELECT_PIN, HIGH);
   readMac();
   serial(F("Attempting to connect to Ethernet"));
   wdt_disable();
-  int key = Keypad_TC::instance()->getKey();
-  long timeout = key == NO_KEY ? 60000 : 1;
   if (Ethernet.begin(mac, timeout)) {
     IP = Ethernet.localIP();
     serial(F("DHCP address is %i.%i.%i.%i"), IP[0], IP[1], IP[2], IP[3]);
@@ -32,13 +30,20 @@ Ethernet_TC::Ethernet_TC() {
   wdt_enable(WDTO_8S);
 }
 
+/**
+ * This method is used in testing.
+ */
 Ethernet_TC *Ethernet_TC::instance(bool reset) {
   if (reset && _instance) {
     delete _instance;
     _instance = nullptr;
   }
+  return instance(); // Call the other instance() method to create the instance if it doesn't exist
+}
+
+Ethernet_TC *Ethernet_TC::instance(long timeout) {
   if (_instance == nullptr) {
-    _instance = new Ethernet_TC;
+    _instance = new Ethernet_TC(timeout);
   }
   return _instance;
 }

--- a/src/wrappers/Ethernet_TC.cpp
+++ b/src/wrappers/Ethernet_TC.cpp
@@ -38,7 +38,7 @@ Ethernet_TC *Ethernet_TC::instance(bool reset) {
     delete _instance;
     _instance = nullptr;
   }
-  return instance(); // Call the other instance() method to create the instance if it doesn't exist
+  return instance();  // Call the other instance() method to create the instance if it doesn't exist
 }
 
 Ethernet_TC *Ethernet_TC::instance(long timeout) {

--- a/src/wrappers/Ethernet_TC.h
+++ b/src/wrappers/Ethernet_TC.h
@@ -10,7 +10,8 @@
 
 class Ethernet_TC {
 public:
-  static Ethernet_TC *instance(bool reset = false);
+  static Ethernet_TC *instance(bool reset);
+  static Ethernet_TC *instance(long timeout = 60000);
   IPAddress getIP() {
     return IP;
   };
@@ -27,7 +28,7 @@ public:
   void loop();
 
 protected:
-  Ethernet_TC();
+  Ethernet_TC(long timeout);
 
 private:
   static Ethernet_TC *_instance;

--- a/test/ResetEEPROMTest.cpp
+++ b/test/ResetEEPROMTest.cpp
@@ -1,0 +1,69 @@
+/**
+ * ResetEEPROMTest.cpp
+ *
+ * Tests for the ResetEEPROM UIState. These tests cover the behavior reachable
+ * from outside the 'A'/'D' branches: prompt rendering, state identity, and
+ * the no-op handling of every other key.
+ *
+ * The 'A' and 'D' branches are intentionally NOT exercised here: both end in
+ *   wdt_enable(WDTO_15MS);
+ *   do { } while (true);
+ * which the arduino_ci mocks cannot break out of -- entering them would hang
+ * the test process. Those branches are validated by manual hardware testing.
+ */
+#include <Arduino.h>
+#include <ArduinoUnitTests.h>
+
+#include "Keypad_TC.h"
+#include "LiquidCrystal_TC.h"
+#include "ResetEEPROM.h"
+#include "TankController.h"
+
+// globals for the singletons used in every test
+TankController* tc = TankController::instance();
+LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
+Keypad* keypad = Keypad_TC::instance()->_getPuppet();
+
+// reduce duplicate code and make it more explicit
+void enterKey(char key) {
+  keypad->push_back(key);
+  tc->loop();  // recognize and apply the key entry
+}
+
+unittest_setup() {
+  tc->setNextState(new ResetEEPROM(), true);
+}
+
+// 1) Prompt is rendered on entry: line 0 is the question, line 1 is the cancel hint.
+unittest(promptIsRenderedOnEntry) {
+  assertEqual("A: Erase EEPROM ", lc->getLines().at(0));
+  assertEqual("D: Cancel       ", lc->getLines().at(1));
+}
+
+// 2) State identity: stateName() reports "ResetEEPROM" while in this state.
+unittest(stateNameIsResetEEPROM) {
+  assertEqual("ResetEEPROM", tc->stateName());
+}
+
+// 3) isInCalibration() returns true so background controllers/writers stay
+//    quiet while the user is deciding whether to wipe the EEPROM.
+unittest(isInCalibrationIsTrue) {
+  assertTrue(tc->isInCalibration());
+}
+
+// 4) Keys other than 'A' and 'D' are no-ops: the state and the on-screen
+//    prompt are both unchanged. This pins down the current `default: break;`
+//    behavior so a future edit can't silently add (e.g.) a returnToMainMenu()
+//    that would let an accidental keypress drop the user out of the prompt.
+unittest(unhandledKeysAreNoOps) {
+  const char unhandledKeys[] = {'0', '1', '2', '3', '4', '5', '6',
+                                '7', '8', '9', 'B', 'C', '*', '#'};
+  for (size_t i = 0; i < sizeof(unhandledKeys); ++i) {
+    enterKey(unhandledKeys[i]);
+    assertEqual("ResetEEPROM", tc->stateName());
+    assertEqual("A: Erase EEPROM ", lc->getLines().at(0));
+    assertEqual("D: Cancel       ", lc->getLines().at(1));
+  }
+}
+
+unittest_main()

--- a/test/ResetEEPROMTest.cpp
+++ b/test/ResetEEPROMTest.cpp
@@ -56,8 +56,7 @@ unittest(isInCalibrationIsTrue) {
 //    behavior so a future edit can't silently add (e.g.) a returnToMainMenu()
 //    that would let an accidental keypress drop the user out of the prompt.
 unittest(unhandledKeysAreNoOps) {
-  const char unhandledKeys[] = {'0', '1', '2', '3', '4', '5', '6',
-                                '7', '8', '9', 'B', 'C', '*', '#'};
+  const char unhandledKeys[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'B', 'C', '*', '#'};
   for (size_t i = 0; i < sizeof(unhandledKeys); ++i) {
     enterKey(unhandledKeys[i]);
     assertEqual("ResetEEPROM", tc->stateName());


### PR DESCRIPTION
To resolve #509. These changes allow the user to reset EEPROM to factory default. During the TankController boot sequence the user holds '1' on the keypad. This blocks all EEPROM reading/writing while the UI asks the user whether to reset EEPROM. Then the device reboots.

Handling of keypresses during the boot sequence is moved from the Ethernet_TC constructor to TankController instance creation so that keypresses can be used for purposes other than disabling Ethernet.